### PR TITLE
docs: Fix documentation URLs and hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,12 +466,6 @@ def test_health(mock_api_url):
 
 ## 📚 API Documentation
 
-### Online Documentation
-
-- 📖 **Full Documentation**: https://socialseed-e2e.readthedocs.io/ (Hosted on ReadTheDocs)
-- 🔗 **API Reference**: https://socialseed-e2e.readthedocs.io/en/latest/api/core.html
-- 📚 **Guides**: https://socialseed-e2e.readthedocs.io/en/latest/
-
 ### Local Documentation
 
 Build and view documentation locally:
@@ -486,6 +480,25 @@ make html
 
 # View in browser
 open _build/html/index.html
+```
+
+### Hosting Documentation Online
+
+To host the documentation on ReadTheDocs:
+
+1. Sign up at https://readthedocs.org/
+2. Import your GitHub repository
+3. The `.readthedocs.yaml` file is already configured
+4. Documentation will be available at: `https://socialseed-e2e.readthedocs.io/`
+
+To host on GitHub Pages:
+
+```bash
+# Build docs and copy to docs/_build/html
+cd docs && make html
+
+# The HTML files are in _build/html/
+# Follow GitHub Pages instructions to deploy this folder
 ```
 
 ### Documentation Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ socialseed-e2e = "socialseed_e2e.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/daironpf/socialseed-e2e"
-Documentation = "https://github.com/daironpf/socialseed-e2e#readme"
+Documentation = "https://github.com/daironpf/socialseed-e2e/tree/main/docs"
 Repository = "https://github.com/daironpf/socialseed-e2e"
 Issues = "https://github.com/daironpf/socialseed-e2e/issues"
 Changelog = "https://github.com/daironpf/socialseed-e2e/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Remove non-existent ReadTheDocs URLs from README:
- Remove https://socialseed-e2e.readthedocs.io/ links (project not yet configured)
- Add clear instructions for building docs locally
- Add step-by-step guide for hosting on ReadTheDocs
- Add alternative GitHub Pages hosting instructions
- Update pyproject.toml Documentation URL to point to docs folder

Users can now:
1. Build docs locally with 'cd docs && make html'
2. Host on ReadTheDocs by importing the GitHub repo
3. Deploy to GitHub Pages using the built HTML files