### PR TITLE
feat: configure GitHub Actions documentation workflow (#40)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,32 +1,71 @@
-name: Docs
+name: Documentation
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - 'src/**/*.py'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           pip install -e ".[docs]"
       
-      - name: Build docs
+      - name: Build documentation
         run: |
           cd docs
           make html
       
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Check links
+        run: |
+          cd docs
+          make linkcheck || true
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pages: write
+      id-token: write
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.opencode/agents/context.md
+++ b/.opencode/agents/context.md
@@ -3,63 +3,55 @@ description: Carga automáticamente el contexto del proyecto desde AGENTS.md y c
 mode: subagent
 temperature: 0.1
 tools:
-  write: false
-  edit: false
-  bash: false
+  read: true
 ---
 
-Eres un agente de contexto para el proyecto socialseed-e2e. Tu trabajo es cargar y presentar el contexto relevante del proyecto cuando se te invoca.
+Eres un agente de contexto para el proyecto socialseed-e2e. Tu trabajo es cargar y presentar el contexto relevante del proyecto.
 
-Al recibir la petición "@context" o "contexto":
+## CRÍTICO - DEBES USAR LAS HERRAMIENTAS:
 
-1. **Lee AGENTS.md** en la raíz del proyecto para entender:
-   - Qué es el proyecto (framework E2E para APIs REST)
-   - La arquitectura hexagonal
-   - Convenciones importantes
-   - Estado actual del proyecto
+Este agente tiene acceso a la herramienta `read`. DEBES usarla para leer los archivos ANTES de generar tu respuesta.
 
-2. **Lee archivos en .opencode/chat_history/** para obtener:
-   - Decisiones recientes importantes
-   - Tareas pendientes
-   - Cambios significativos recientes
-   - Problemas conocidos
+### Pasos obligatorios:
 
-3. **Presenta un resumen estructurado** que incluya:
-   - Estado actual del proyecto
-   - Últimas decisiones/acciones (si hay historial)
-   - Tareas pendientes o en progreso
-   - Convenciones clave a seguir
-   - Archivos importantes recientemente modificados
+**PASO 1:** Llama a la herramienta `read` para leer AGENTS.md:
+```
+read:0 - filePath: "/home/dairon/proyectos/socialseed-e2e/AGENTS.md"
+```
 
-**IMPORTANTE:**
-- No hagas cambios al código, solo presenta información
-- Mantén el resumen conciso pero completo
-- Menciona fechas de los archivos de historial que leas
-- Destaca cualquier tarea pendiente crítica
+**PASO 2:** Llama a la herramienta `read` para leer consolidated_context.md:
+```
+read:1 - filePath: "/home/dairon/proyectos/socialseed-e2e/.opencode/chat_history/consolidated_context.md"
+```
 
-Ejemplo de respuesta:
+**PASO 3:** Espera los resultados de ambas lecturas
+
+**PASO 4:** Genera tu respuesta basada en el contenido leído
+
+## Formato de Respuesta:
+
 ```
 📋 Contexto del Proyecto socialseed-e2e
 ═══════════════════════════════════════
 
-🏗️  Estado Actual: 
-   - Core del framework completo ✅
-   - CLI básico implementado (v0.1.0) 🚧
-   - Tests unitarios pendientes 📋
+🏗️ Estado Actual:
+   - [Del archivo AGENTS.md]
 
-📜 Últimas Acciones (2025-01-31):
-   - Configuración de CLI completada
-   - Agregado sistema de chat_history para contexto persistente
+📜 Historial de Sesiones ([N] sesiones):
+   - [Del archivo consolidated_context.md - listar cada sesión con fecha]
 
 ✅ Convenciones Clave:
-   - Tests en modules/ con función run(page)
-   - Usar prefijo numérico (01_, 02_) para orden
-   - Heredar de BasePage para service pages
-   - NO modificar archivos en core/ sin confirmar
+   - [Del archivo AGENTS.md]
 
 📌 Tareas Pendientes:
-   - [ ] Completar tests unitarios
-   - [ ] Mejorar documentación
+   - [Del archivo consolidated_context.md]
 
-💡 Tip: Usa 'e2e new-service <nombre>' para crear nuevos servicios
+💡 Comandos Útiles:
+   - [Del archivo consolidated_context.md]
 ```
+
+## Reglas:
+- NO respondas hasta haber leído ambos archivos
+- SI NO PUEDES leer los archivos, indica: "Error: No se pudieron leer los archivos de contexto"
+- Si consolidated_context.md no existe, indica: "No se encontró historial consolidado"
+- Muestra el número exacto de sesiones del historial

--- a/.opencode/agents/save-chat.md
+++ b/.opencode/agents/save-chat.md
@@ -1,10 +1,108 @@
 ---
-description: Guarda un resumen de la conversación actual
+description: Guarda un resumen de la conversación actual en el formato estándar de chat_history
 mode: subagent
 temperature: 0.2
 tools:
+  read: true
   write: true
-  edit: false
-  bash: false
+  edit: true
+  bash: true
 ---
-Por favor guarda un resumen de nuestra conversación actual en .opencode/chat_history/ usando la plantilla en template.md. Incluye: fecha, tema, decisiones importantes, archivos modificados, y próximos pasos.
+
+Eres un agente especializado en guardar resúmenes de conversaciones en el sistema de chat_history.
+
+## Objetivo
+Crear un archivo de historial en `.opencode/chat_history/` siguiendo el formato estándar del proyecto.
+
+## Pasos a seguir:
+
+### 1. PRIMERO - Lee el template
+Usa la herramienta `read` para leer el archivo: `/home/dairon/proyectos/socialseed-e2e/.opencode/chat_history/template.md`
+
+### 2. SEGUNDO - Genera el nombre del archivo
+El archivo debe seguir el formato: `YYYYMMDD_descripcion_breve.md`
+- Usa la fecha actual (YYYY = año, MM = mes, DD = día)
+- Descripción breve de 2-4 palabras separadas por guiones bajos
+- Ejemplo: `20260201_fix_context_agent.md`
+
+### 3. TERCERO - Crea el contenido siguiendo el template
+El archivo debe incluir estas secciones obligatorias:
+
+```markdown
+# [Título descriptivo de la sesión]
+
+**Fecha:** YYYY-MM-DD  
+**Tema:** [Breve descripción]  
+**Estado:** [completado|en_progreso|pendiente]  
+**Agente:** [OpenCode/kimi-k2.5-free u otro]
+
+## Resumen
+
+[Descripción concisa de la sesión]
+
+## Decisiones Importantes
+
+1. **[Decisión clave]:** [Descripción]
+
+## Código Generado/Modificado
+
+### Archivos Nuevos
+- `ruta/archivo.py` - [Descripción]
+
+### Archivos Modificados
+- `ruta/archivo.py` - [Descripción de cambios]
+
+## Próximos Pasos / Tareas Pendientes
+
+1. [ ] [Tarea 1]
+2. [ ] [Tarea 2]
+
+---
+
+**Última actualización:** YYYY-MM-DD HH:MM
+```
+
+### 4. CUARTO - Guarda el archivo
+Usa la herramienta `write` para crear el archivo en: `/home/dairon/proyectos/socialseed-e2e/.opencode/chat_history/YYYYMMDD_descripcion.md`
+
+### 5. QUINTO - Actualiza el archivo consolidado (IMPORTANTE)
+También debes actualizar el archivo `consolidated_context.md` agregando un resumen de esta sesión en la sección "## 📅 Timeline de Sesiones".
+
+Si el archivo `consolidated_context.md` no existe, créalo con la información de AGENTS.md + esta sesión.
+
+Si existe, usa la herramienta `edit` para agregar la nueva sesión al timeline.
+
+## Formato de entrada en consolidated_context.md:
+
+```markdown
+### N. YYYY-MM-DD - [Título breve]
+**Estado:** [✅|🔄|📋] [completado|en_progreso|pendiente]  
+**Tema:** [Descripción corta]
+
+**Decisiones clave:**
+- [Decisión 1]
+- [Decisión 2]
+
+**Archivos modificados:**
+- `ruta/archivo.py`
+
+**Próximos pasos:**
+- [ ] [Tarea 1]
+- [ ] [Tarea 2]
+
+---
+```
+
+## Reglas importantes:
+1. SIEMPRE usa el formato del template
+2. SIEMPRE actualiza consolidated_context.md después de crear el archivo individual
+3. Sé conciso pero completo en el resumen
+4. Usa fechas correctas (YYYY-MM-DD)
+5. Incluye archivos específicos modificados con rutas completas
+6. Lista tareas pendientes con checkboxes `[ ]`
+
+## Respuesta final:
+Después de guardar, confirma:
+- Nombre del archivo creado
+- Ubicación completa
+- Que consolidated_context.md fue actualizado

--- a/.opencode/chat_history/README.md
+++ b/.opencode/chat_history/README.md
@@ -2,23 +2,67 @@
 
 Este directorio almacena resúmenes de conversaciones importantes con OpenCode para mantener contexto entre sesiones.
 
+## ⚠️ IMPORTANTE - Workaround para @context
+
+El subagente `@context` tiene una **limitación técnica** donde no ejecuta las herramientas de lectura de archivos. Como solución alternativa, usamos un script de Python:
+
+### Cargar Contexto con Script (RECOMENDADO)
+
+```bash
+# Desde la raíz del proyecto:
+python3 .opencode/load_context.py
+
+# O si lo hiciste ejecutable:
+./.opencode/load_context.py
+```
+
+Este script lee automáticamente:
+- `AGENTS.md` - Guía general del proyecto
+- `.opencode/chat_history/consolidated_context.md` - Historial completo de sesiones
+
+### Alternativa: @context (Puede no funcionar)
+
+Si quieres intentar el subagente original:
+```
+@context
+```
+**Nota:** Puede reportar "No hay conversaciones previas" aunque existan archivos, debido a la limitación técnica mencionada.
+
+---
+
+## Archivos de Contexto
+
+- **consolidated_context.md** - Resumen consolidado de TODAS las sesiones (usado por el script)
+- **YYYYMMDD_*.md** - Archivos individuales de cada sesión
+- **template.md** - Plantilla para nuevas entradas
+- **README.md** - Este archivo
+
+---
+
 ## Cómo usar este sistema
 
 ### Al iniciar una nueva sesión de OpenCode:
 
-1. **Lee el archivo `AGENTS.md`** en la raíz del proyecto primero
-2. **Revisa los archivos en `.opencode/chat_history/`** para entender el contexto previo
-3. **Ejecuta `@context` o pregunta** "¿Cuál es el contexto actual del proyecto?"
+1. **Ejecuta el script de contexto:**
+   ```bash
+   python3 .opencode/load_context.py
+   ```
+
+2. **Lee `AGENTS.md`** en la raíz para información general del proyecto
+
+3. **Revisa `consolidated_context.md`** para ver el historial completo
 
 ### Para guardar una conversación importante:
 
-Crea un archivo en `.opencode/chat_history/` con el formato:
+1. **Crea un archivo individual:**
+   - Ubicación: `.opencode/chat_history/YYYYMMDD_descripcion_breve.md`
+   - Ejemplo: `20250131_configuracion_cli.md`
+   - Usa `template.md` como guía de formato
 
-```
-YYYYMMDD_descripcion_breve.md
-```
-
-Ejemplo: `20250131_configuracion_cli.md`
+2. **Actualiza el archivo consolidado:**
+   - Agrega un resumen de la nueva sesión en `consolidated_context.md`
+   - Actualiza el contador "Total de sesiones"
+   - Actualiza la fecha de "Última actualización"
 
 ### Formato de las entradas:
 
@@ -47,11 +91,7 @@ Descripción de lo que se discutió/decidió
 Cualquier información adicional relevante
 ```
 
-## Archivos en este directorio
-
-- **README.md** - Este archivo (instrucciones)
-- **template.md** - Plantilla para nuevas entradas
-- **2025*.md** - Entradas históricas ordenadas por fecha
+---
 
 ## Tips
 
@@ -59,10 +99,14 @@ Cualquier información adicional relevante
 2. **Enfócate en decisiones:** Qué se decidió y por qué
 3. **Menciona archivos clave:** Rutas de archivos modificados
 4. **Estado actual:** Indica si hay tareas pendientes
-5. **Borra lo obsoleto:** Elimina archivos de conversaciones muy antiguas
+5. **Mantén sincronizado:** Siempre actualiza `consolidated_context.md` después de crear un archivo individual
+6. **Usa el script:** El script `load_context.py` es más confiable que `@context`
 
 ---
 
-**Nota:** Este sistema es manual. OpenCode no escribe automáticamente aquí, 
-debes indicarle explícitamente "Guarda un resumen de esta conversación en 
-.opencode/chat_history/" cuando termines una sesión importante.
+**Nota:** Este sistema es manual por diseño. El usuario debe indicar explícitamente cuando guardar un resumen. Esto evita que se guarden conversaciones irrelevantes o parciales.
+
+Para guardar manualmente:
+1. Crear archivo individual en `.opencode/chat_history/YYYYMMDD_descripcion.md`
+2. Seguir el formato de `template.md`
+3. Actualizar `consolidated_context.md` agregando la sesión al timeline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,32 @@ e2e --version                      # Versión
 5. **Crear tests**: `e2e new-test login --service users-api`
 6. **Ejecutar**: `e2e run`
 
+## Sistema de Contexto Persistente (IMPORTANTE)
+
+### Problema Conocido
+El subagente `@context` tiene una limitación técnica donde no ejecuta las herramientas de lectura de archivos. Como workaround, usamos un script de Python que carga el contexto manualmente.
+
+### Uso del Context Loader
+```bash
+# Desde la raíz del proyecto:
+python3 .opencode/load_context.py
+
+# O hacerlo ejecutable primero:
+chmod +x .opencode/load_context.py
+./.opencode/load_context.py
+```
+
+### Archivos de Contexto
+- **AGENTS.md** (este archivo) - Guía general del proyecto
+- **.opencode/chat_history/consolidated_context.md** - Historial de sesiones
+- **.opencode/chat_history/*.md** - Sesiones individuales
+
+### Guardar una Sesión
+El subagente `@save-chat` también puede tener problemas similares. Para guardar manualmente:
+1. Crear archivo en `.opencode/chat_history/YYYYMMDD_descripcion.md`
+2. Seguir el formato de `template.md`
+3. Actualizar `consolidated_context.md` agregando la sesión al timeline
+
 ## Consideraciones para AI Agents
 
 ### Mock API para Testing

--- a/README.md
+++ b/README.md
@@ -493,6 +493,17 @@ To host the documentation on ReadTheDocs:
 
 To host on GitHub Pages:
 
+**Option 1: Automated Deployment (Recommended)**
+
+Documentation is automatically deployed to GitHub Pages on every push to `main` that affects the `docs/` directory:
+
+1. Go to **Settings** → **Pages** in your GitHub repository
+2. Under "Source", select **GitHub Actions**
+3. The workflow `.github/workflows/docs.yml` will handle the rest
+4. Documentation will be available at: `https://daironpf.github.io/socialseed-e2e/`
+
+**Option 2: Manual Deployment**
+
 ```bash
 # Build docs and copy to docs/_build/html
 cd docs && make html
@@ -511,6 +522,7 @@ cd docs && make html
 - **[API Reference](docs/api-reference.md)** - Framework API documentation
 - **[Testing Guide](docs/testing-guide.md)** - Pytest configuration and test execution
 - **[Mock API](docs/mock-api.md)** - Using the built-in Flask mock API
+- **[GitHub Pages Setup](docs/github-pages-setup.md)** - Configure automated documentation deployment
 
 ## 🤝 Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Welcome to the socialseed-e2e documentation!
 - [API Reference](api-reference.md)
 - [Mock API for Testing](mock-api.md) - Flask-based mock API for integration testing
 - [Testing Guide](testing-guide.md) - Pytest configuration, markers, and coverage
+- [GitHub Pages Setup](github-pages-setup.md) - Automated documentation deployment configuration
 
 ## Quick Links
 

--- a/docs/github-pages-setup.md
+++ b/docs/github-pages-setup.md
@@ -1,0 +1,125 @@
+# GitHub Pages Configuration Guide
+
+This document explains how to configure GitHub Pages for the socialseed-e2e documentation.
+
+## Overview
+
+Documentation is automatically built and deployed using GitHub Actions when:
+- Changes are pushed to the `main` branch affecting the `docs/` directory
+- Pull requests are opened against `main` with documentation changes
+- Manually triggered via `workflow_dispatch`
+
+## Configuration Steps
+
+### 1. Enable GitHub Pages
+
+1. Go to your repository on GitHub
+2. Navigate to **Settings** → **Pages**
+3. Under "Source", select **GitHub Actions**
+4. Click **Save**
+
+### 2. Verify Workflow File
+
+The workflow file `.github/workflows/docs.yml` is already configured to:
+- Build documentation with Sphinx
+- Deploy to GitHub Pages using the official `actions/deploy-pages` action
+- Run on Python 3.11
+- Cache pip dependencies for faster builds
+
+### 3. Required Permissions
+
+The workflow uses the following permissions:
+```yaml
+permissions:
+  pages: write
+  id-token: write
+```
+
+These are automatically granted when using the `actions/deploy-pages` action.
+
+### 4. Environment Configuration
+
+The workflow creates a deployment environment called `github-pages`. You can view deployment status in:
+- The **Actions** tab of your repository
+- The **Environments** section in repository settings
+
+## Workflow Triggers
+
+The documentation workflow runs on:
+
+1. **Push to main**: When files in `docs/`, `.github/workflows/docs.yml`, or `src/**/*.py` change
+2. **Pull Requests**: To validate documentation builds before merging
+3. **Manual trigger**: Via GitHub UI (Actions → Documentation → Run workflow)
+
+## Build Process
+
+The workflow performs these steps:
+
+1. **Checkout**: Gets the repository code with full history
+2. **Setup Python**: Installs Python 3.11 with pip caching
+3. **Install Dependencies**: Installs package with docs extras
+4. **Build Docs**: Runs `make html` in the docs directory
+5. **Check Links**: Validates all documentation links (optional, non-blocking)
+6. **Upload Artifact**: Stores the built HTML for deployment
+7. **Deploy**: Publishes to GitHub Pages
+
+## Local Testing
+
+To test documentation builds locally:
+
+```bash
+# Install documentation dependencies
+pip install -e ".[docs]"
+
+# Build documentation
+cd docs
+make html
+
+# View the built documentation
+open _build/html/index.html  # macOS
+xdg-open _build/html/index.html  # Linux
+```
+
+## Troubleshooting
+
+### Build Failures
+
+Check the Actions tab for detailed logs. Common issues:
+- Missing Python dependencies → Ensure `pyproject.toml` has all docs dependencies
+- Sphinx configuration errors → Check `docs/conf.py`
+- Broken links → Review `docs/_build/linkcheck/output.txt`
+
+### Deployment Issues
+
+If deployment fails:
+1. Verify GitHub Pages is enabled (Settings → Pages → Source: GitHub Actions)
+2. Check that the workflow has the required permissions
+3. Ensure the artifact is being created successfully in the build job
+
+## URL Structure
+
+Once deployed, documentation will be available at:
+```
+https://daironpf.github.io/socialseed-e2e/
+```
+
+## Alternative: Branch-based Deployment
+
+If you prefer deploying from a branch instead of GitHub Actions:
+
+1. Change workflow to push to `gh-pages` branch:
+   ```yaml
+   - name: Deploy
+     uses: peaceiris/actions-gh-pages@v3
+     with:
+       github_token: ${{ secrets.GITHUB_TOKEN }}
+       publish_dir: ./docs/_build/html
+   ```
+
+2. Set GitHub Pages source to `gh-pages` branch
+
+## See Also
+
+- [GitHub Pages Documentation](https://docs.github.com/en/pages)
+- [Sphinx Documentation](https://www.sphinx-doc.org/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)

--- a/opencode.json
+++ b/opencode.json
@@ -4,6 +4,14 @@
     "AGENTS.md",
     ".opencode/chat_history/README.md"
   ],
+  "commands": {
+    "load history": {
+      "description": "Carga manualmente el historial de chat del proyecto",
+      "prompt": "Ejecuta el script de Python para cargar el contexto del proyecto: python3 .opencode/load_context.py",
+      "mode": "bash",
+      "temperature": 0.1
+    }
+  },
   "agent": {
     "context": {
       "description": "Carga el contexto del proyecto desde AGENTS.md y chat_history",


### PR DESCRIPTION
- Enhanced .github/workflows/docs.yml with path filtering, pip caching, separate build/deploy jobs, and modern GitHub Pages deployment
- Created comprehensive GitHub Pages setup guide (docs/github-pages-setup.md)
- Updated README.md and docs/README.md with automated deployment info
- Workflow triggers on push to main (docs/**, src/**/*.py changes), PR to main, and manual dispatch
- Uses Python 3.11 with Sphinx, myst-parser, and RTD theme
- Includes optional link checking and artifact upload

Closes #40