### PR TITLE
feat(#187): Generate AI Discovery Report after first scan

### DIFF
--- a/docs/ai-discovery-report.md
+++ b/docs/ai-discovery-report.md
@@ -1,0 +1,433 @@
+# AI Discovery Report (Issue #187)
+
+## Overview
+
+The **AI Discovery Report** is a comprehensive summary automatically generated after scanning your project. It presents a "Mental Map" of what the AI understood about your codebase, including discovered endpoints, business flows, and generated test suites.
+
+## What is a Discovery Report?
+
+After running `e2e manifest` or `e2e generate-tests`, the AI analyzes your project and creates a detailed report that says something like:
+
+> "I've analyzed your project. I found **15 REST endpoints** in **Java/Spring**. I've created **3 complex user flows** (Auth, Management, CRUD) in your `services/` folder. Ready to run?"
+
+## Features
+
+### 📊 Project Statistics
+- Total services discovered
+- REST endpoints count
+- DTOs/Models identified
+- Business flows detected
+- Test files generated
+
+### 🧠 Mental Map
+The report includes:
+- **Technology Stack**: Frameworks and languages detected
+- **Service Architecture**: Microservices and their relationships
+- **Business Flows**: Authentication, CRUD, Management, etc.
+- **Endpoint Inventory**: All discovered API endpoints
+
+### 🚀 Single Command Execution
+The report provides a single command to run all tests:
+```bash
+e2e run
+```
+
+## Usage
+
+### Automatic Generation
+
+The Discovery Report is automatically generated after:
+
+```bash
+# After generating tests
+e2e generate-tests
+
+# Output:
+# 📝 Generating AI Discovery Report...
+#    ✓ Report saved: /project/.e2e/DISCOVERY_REPORT.md
+```
+
+### Manual Generation
+
+Generate the report at any time:
+
+```bash
+# Generate for current project
+e2e discover
+
+# Generate for specific project
+e2e discover /path/to/project
+
+# Generate and open the report
+e2e discover --open
+```
+
+### View the Report
+
+The report is saved as a markdown file:
+
+```bash
+# Open the report
+cat .e2e/DISCOVERY_REPORT.md
+
+# Or use --open flag
+e2e discover --open
+```
+
+## Report Structure
+
+### 1. Header
+```markdown
+# 🔍 AI Discovery Report
+
+**Project:** `my-api`
+**Path:** `/home/user/my-api`
+**Generated:** 2026-02-08 15:30:45
+```
+
+### 2. Technology Stack
+```markdown
+### 📦 Technology Stack
+
+- **users-service**: Spring Boot (java)
+- **payment-service**: FastAPI (python)
+```
+
+### 3. Statistics
+```markdown
+### 📊 Project Statistics
+
+| Metric | Count |
+|--------|-------|
+| Services | 3 |
+| REST Endpoints | 15 |
+| DTOs/Models | 12 |
+| Business Flows | 3 |
+| Test Files Generated | 8 |
+```
+
+### 4. Discovered Flows
+```markdown
+### 🌊 Discovered Business Flows
+
+#### 🔐 User Authentication Flow
+
+- **Description:** Complete user registration and authentication flow
+- **Type:** Authentication
+- **Endpoints:** 3
+- **Complexity:** 🟢 Simple
+
+#### 📋 User CRUD Operations
+
+- **Description:** Full CRUD lifecycle for user entities
+- **Type:** Crud
+- **Endpoints:** 4
+- **Complexity:** 🟡 Moderate
+```
+
+### 5. Quick Start
+```markdown
+## 🚀 Ready to Run?
+
+### Execute All Tests
+
+```bash
+cd /home/user/my-api
+e2e run
+```
+```
+
+### 6. Command Reference
+```markdown
+### 📖 Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `e2e run` | Run all tests |
+| `e2e run --service <name>` | Run tests for specific service |
+| `e2e run --verbose` | Run with detailed output |
+```
+
+## Example Report
+
+Here's a complete example:
+
+```markdown
+# 🔍 AI Discovery Report
+
+**Project:** `ecommerce-api`
+**Path:** `/home/user/ecommerce-api`
+**Generated:** 2026-02-08 15:30:45
+
+---
+
+## 🧠 Mental Map of Your Project
+
+### 📦 Technology Stack
+
+- **users-service**: Spring Boot (java)
+- **products-service**: FastAPI (python)
+- **orders-service**: Express.js (javascript)
+
+### 📊 Project Statistics
+
+| Metric | Count |
+|--------|-------|
+| Services | 3 |
+| REST Endpoints | 24 |
+| DTOs/Models | 18 |
+| Business Flows | 5 |
+| Test Files Generated | 12 |
+
+### 🌊 Discovered Business Flows
+
+#### 🔐 User Authentication Flow
+- **Description:** Registration → Login → Token refresh
+- **Type:** Authentication
+- **Endpoints:** 3
+- **Complexity:** 🟢 Simple
+
+#### 📋 Product Catalog Management
+- **Description:** Create, list, update, delete products
+- **Type:** Crud
+- **Endpoints:** 5
+- **Complexity:** 🟡 Moderate
+
+#### 🛒 Complete Checkout Flow
+- **Description:** Cart → Checkout → Payment → Order confirmation
+- **Type:** Workflow
+- **Endpoints:** 6
+- **Complexity:** 🔴 Complex
+
+---
+
+## 🚀 Ready to Run?
+
+I've analyzed your project and created comprehensive test suites.
+
+### Execute All Tests
+
+```bash
+cd /home/user/ecommerce-api
+e2e run
+```
+
+✅ **Ready to run?** Execute: `e2e run`
+```
+
+## API Usage
+
+### Generate Report Programmatically
+
+```python
+from socialseed_e2e.project_manifest import generate_discovery_report
+from pathlib import Path
+
+# Generate report
+report_path = generate_discovery_report(
+    project_root=Path("/path/to/project"),
+    manifest=manifest,  # Optional: ProjectKnowledge object
+    flows=discovered_flows,  # Optional: List of flows
+    tests_generated=8,  # Optional: Number of test files
+)
+
+print(f"Report generated: {report_path}")
+```
+
+### Using DiscoveryReportGenerator
+
+```python
+from socialseed_e2e.project_manifest import DiscoveryReportGenerator
+from pathlib import Path
+
+# Create generator
+generator = DiscoveryReportGenerator(Path("/path/to/project"))
+
+# Generate report
+report_path = generator.generate_report(
+    manifest=manifest,
+    flows=flows,
+    tests_generated=8,
+    output_dir=Path("services")
+)
+```
+
+## CLI Reference
+
+### `e2e discover`
+
+**Syntax:**
+```bash
+e2e discover [DIRECTORY] [OPTIONS]
+```
+
+**Arguments:**
+- `DIRECTORY`: Project directory (default: current directory)
+
+**Options:**
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--output` | `-o` | Output directory for report | `.e2e/` |
+| `--open` | `--view` | Open the report after generation | Disabled |
+
+**Examples:**
+
+```bash
+# Generate for current project
+e2e discover
+
+# Generate for specific project
+e2e discover /path/to/project
+
+# Generate and open
+e2e discover --open
+
+# Generate with custom output
+e2e discover --output ./reports
+```
+
+## Integration with Other Commands
+
+### After `e2e manifest`
+
+```bash
+e2e manifest
+e2e discover  # Generate report from manifest
+```
+
+### After `e2e generate-tests`
+
+The report is generated automatically:
+
+```bash
+e2e generate-tests
+
+# Output includes:
+# 📝 Generating AI Discovery Report...
+#    ✓ Report saved: .e2e/DISCOVERY_REPORT.md
+```
+
+### After `e2e observe`
+
+Combine with service detection:
+
+```bash
+e2e observe  # Detect running services
+e2e discover  # Generate report
+```
+
+## Customization
+
+### Report Location
+
+By default, reports are saved to `.e2e/DISCOVERY_REPORT.md`:
+
+```
+project/
+├── .e2e/
+│   └── DISCOVERY_REPORT.md
+├── services/
+└── e2e.conf
+```
+
+### Report Content
+
+The report automatically includes:
+- ✅ Project metadata
+- ✅ Technology stack
+- ✅ Service statistics
+- ✅ Business flows
+- ✅ Execution commands
+- ✅ Quick reference
+
+## Troubleshooting
+
+### "No project manifest found"
+
+**Problem**: Report generation requires a manifest.
+
+**Solution:**
+```bash
+# Generate manifest first
+e2e manifest
+
+# Then generate report
+e2e discover
+```
+
+### Report not updating
+
+**Problem**: Old report showing outdated information.
+
+**Solution:**
+```bash
+# Force regeneration
+e2e manifest --force
+e2e generate-tests --force
+e2e discover
+```
+
+### Missing flows in report
+
+**Problem**: Business flows not appearing.
+
+**Solution:**
+Flows are detected during `e2e generate-tests`. Make sure to run that command first.
+
+## Best Practices
+
+### 1. Review After Generation
+
+Always review the Discovery Report after generation:
+
+```bash
+e2e generate-tests
+cat .e2e/DISCOVERY_REPORT.md
+```
+
+### 2. Share with Team
+
+The report is a great way to onboard new developers:
+
+```bash
+# Commit the report
+git add .e2e/DISCOVERY_REPORT.md
+git commit -m "docs: Add AI Discovery Report"
+```
+
+### 3. Keep Updated
+
+Regenerate when code changes:
+
+```bash
+# After major code changes
+e2e manifest --force
+e2e discover
+```
+
+## Comparison with Other Features
+
+| Feature | Purpose | Output |
+|---------|---------|--------|
+| `e2e manifest` | Analyze code | `project_knowledge.json` |
+| `e2e generate-tests` | Create tests | `services/` directory |
+| `e2e observe` | Find running services | CLI output |
+| `e2e discover` | **Generate report** | **`.e2e/DISCOVERY_REPORT.md`** |
+
+## Future Enhancements
+
+Planned improvements for Issue #187:
+
+- [ ] Interactive HTML report
+- [ ] Visual service dependency graph
+- [ ] API diff reporting (what changed since last scan)
+- [ ] Integration with CI/CD pipelines
+- [ ] Export to PDF
+- [ ] Custom report templates
+
+## See Also
+
+- [Autonomous Test Generation](autonomous-test-generation-guide.md) - How tests are generated
+- [The Observer](the-observer.md) - Service detection
+- [Project Manifest](project-manifest.md) - Underlying data structure

--- a/src/socialseed_e2e/project_manifest/__init__.py
+++ b/src/socialseed_e2e/project_manifest/__init__.py
@@ -49,6 +49,14 @@ from socialseed_e2e.project_manifest.deep_scanner import (
     EnvironmentDetector,
     TechStackDetector,
 )
+
+# AI Discovery Report (Issue #187)
+from socialseed_e2e.project_manifest.discovery_report import (
+    DiscoveredFlow,
+    DiscoveryReportGenerator,
+    DiscoverySummary,
+    generate_discovery_report,
+)
 from socialseed_e2e.project_manifest.dummy_data_generator import (
     DataGenerationContext,
     DataGenerationStrategy,
@@ -144,4 +152,9 @@ __all__ = [
     "DetectedService",
     "DockerContainer",
     "DockerSetupSuggestion",
+    # AI Discovery Report (Issue #187)
+    "DiscoveryReportGenerator",
+    "DiscoverySummary",
+    "DiscoveredFlow",
+    "generate_discovery_report",
 ]

--- a/src/socialseed_e2e/project_manifest/discovery_report.py
+++ b/src/socialseed_e2e/project_manifest/discovery_report.py
@@ -1,0 +1,456 @@
+"""AI Discovery Report Generator for socialseed-e2e.
+
+This module generates a comprehensive "Discovery Report" after the first scan,
+presenting a "Mental Map" of the AI's understanding of the developer's project.
+
+Issue #187: Generate an AI "Discovery Report" after the first scan
+"""
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from socialseed_e2e.project_manifest.models import ProjectKnowledge, ServiceInfo
+
+
+@dataclass
+class DiscoveredFlow:
+    """A discovered business flow in the project."""
+
+    name: str
+    description: str
+    endpoints_count: int
+    flow_type: str  # 'authentication', 'crud', 'management', 'custom'
+    complexity: str  # 'simple', 'moderate', 'complex'
+
+
+@dataclass
+class DiscoverySummary:
+    """Summary of discovered project information."""
+
+    project_name: str
+    project_path: Path
+    analysis_timestamp: datetime
+    tech_stack: Dict[str, Any]
+    services_count: int
+    endpoints_count: int
+    dtos_count: int
+    flows_discovered: List[DiscoveredFlow]
+    tests_generated: int
+    output_directory: Path
+
+
+class DiscoveryReportGenerator:
+    """Generates AI Discovery Reports after scanning projects."""
+
+    def __init__(self, project_root: Path, output_dir: Optional[Path] = None):
+        """Initialize the discovery report generator.
+
+        Args:
+            project_root: Root directory of the project
+            output_dir: Directory where reports will be saved (default: project_root/.e2e)
+        """
+        self.project_root = Path(project_root).resolve()
+        self.output_dir = output_dir or (self.project_root / ".e2e")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate_report(
+        self,
+        manifest: Optional[ProjectKnowledge] = None,
+        flows: Optional[List[Dict[str, Any]]] = None,
+        tests_generated: int = 0,
+        output_dir: Optional[Path] = None,
+    ) -> Path:
+        """Generate the discovery report.
+
+        Args:
+            manifest: Project manifest with discovered information
+            flows: List of discovered flows from business logic inference
+            tests_generated: Number of test files generated
+            output_dir: Directory where tests were generated
+
+        Returns:
+            Path to the generated report file
+        """
+        # Load manifest if not provided
+        if manifest is None:
+            manifest = self._load_manifest()
+
+        # Create summary
+        summary = self._create_summary(manifest, flows, tests_generated, output_dir)
+
+        # Generate markdown report
+        report_path = self._generate_markdown_report(summary)
+
+        # Also generate CLI summary
+        self._print_cli_summary(summary)
+
+        return report_path
+
+    def _load_manifest(self) -> Optional[ProjectKnowledge]:
+        """Load existing project manifest."""
+        manifest_path = self.project_root / "project_knowledge.json"
+        if not manifest_path.exists():
+            return None
+
+        try:
+            with open(manifest_path, "r") as f:
+                data = json.load(f)
+
+            # Parse into ProjectKnowledge (simplified)
+            return ProjectKnowledge(**data)
+        except Exception:
+            return None
+
+    def _create_summary(
+        self,
+        manifest: Optional[ProjectKnowledge],
+        flows: Optional[List[Dict[str, Any]]],
+        tests_generated: int,
+        output_dir: Optional[Path],
+    ) -> DiscoverySummary:
+        """Create discovery summary from manifest and flows."""
+
+        # Get project name
+        project_name = self.project_root.name
+
+        # Count services and endpoints
+        services_count = 0
+        endpoints_count = 0
+        dtos_count = 0
+        tech_stack = {}
+
+        if manifest:
+            services = getattr(manifest, "services", [])
+            services_count = len(services)
+
+            for service in services:
+                endpoints_count += len(getattr(service, "endpoints", []))
+                dtos_count += len(getattr(service, "dto_schemas", []))
+
+                # Get tech stack info
+                framework = getattr(service, "framework", None)
+                language = getattr(service, "language", "unknown")
+
+                if framework:
+                    tech_stack[service.name] = {
+                        "framework": framework,
+                        "language": language,
+                    }
+
+        # Process flows
+        discovered_flows = []
+        if flows:
+            for flow in flows:
+                discovered_flows.append(
+                    DiscoveredFlow(
+                        name=flow.get("name", "Unknown Flow"),
+                        description=flow.get("description", ""),
+                        endpoints_count=len(flow.get("steps", [])),
+                        flow_type=flow.get("flow_type", "custom"),
+                        complexity=self._calculate_complexity(flow),
+                    )
+                )
+
+        return DiscoverySummary(
+            project_name=project_name,
+            project_path=self.project_root,
+            analysis_timestamp=datetime.now(),
+            tech_stack=tech_stack,
+            services_count=services_count,
+            endpoints_count=endpoints_count,
+            dtos_count=dtos_count,
+            flows_discovered=discovered_flows,
+            tests_generated=tests_generated,
+            output_directory=output_dir or self.project_root / "services",
+        )
+
+    def _calculate_complexity(self, flow: Dict[str, Any]) -> str:
+        """Calculate flow complexity based on steps and relationships."""
+        steps_count = len(flow.get("steps", []))
+
+        if steps_count <= 2:
+            return "simple"
+        elif steps_count <= 4:
+            return "moderate"
+        else:
+            return "complex"
+
+    def _generate_markdown_report(self, summary: DiscoverySummary) -> Path:
+        """Generate markdown discovery report."""
+        report_path = self.output_dir / "DISCOVERY_REPORT.md"
+
+        # Build the report content
+        content = self._build_markdown_content(summary)
+
+        # Write to file
+        with open(report_path, "w") as f:
+            f.write(content)
+
+        return report_path
+
+    def _build_markdown_content(self, summary: DiscoverySummary) -> str:
+        """Build the markdown report content."""
+
+        lines = [
+            "# 🔍 AI Discovery Report",
+            "",
+            f"**Project:** `{summary.project_name}`  ",
+            f"**Path:** `{summary.project_path}`  ",
+            f"**Generated:** {summary.analysis_timestamp.strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+            "---",
+            "",
+            "## 🧠 Mental Map of Your Project",
+            "",
+        ]
+
+        # Tech Stack Summary
+        if summary.tech_stack:
+            lines.extend(
+                [
+                    "### 📦 Technology Stack",
+                    "",
+                ]
+            )
+
+            for service_name, tech in summary.tech_stack.items():
+                framework = tech.get("framework", "Unknown")
+                language = tech.get("language", "Unknown")
+                lines.append(f"- **{service_name}**: {framework} ({language})")
+
+            lines.append("")
+
+        # Statistics
+        lines.extend(
+            [
+                "### 📊 Project Statistics",
+                "",
+                f"| Metric | Count |",
+                f"|--------|-------|",
+                f"| Services | {summary.services_count} |",
+                f"| REST Endpoints | {summary.endpoints_count} |",
+                f"| DTOs/Models | {summary.dtos_count} |",
+                f"| Business Flows | {len(summary.flows_discovered)} |",
+                f"| Test Files Generated | {summary.tests_generated} |",
+                "",
+            ]
+        )
+
+        # Discovered Flows
+        if summary.flows_discovered:
+            lines.extend(
+                [
+                    "### 🌊 Discovered Business Flows",
+                    "",
+                ]
+            )
+
+            for flow in summary.flows_discovered:
+                emoji = self._get_flow_emoji(flow.flow_type)
+                complexity_emoji = self._get_complexity_emoji(flow.complexity)
+                lines.extend(
+                    [
+                        f"#### {emoji} {flow.name}",
+                        "",
+                        f"- **Description:** {flow.description}",
+                        f"- **Type:** {flow.flow_type.title()}",
+                        f"- **Endpoints:** {flow.endpoints_count}",
+                        f"- **Complexity:** {complexity_emoji} {flow.complexity.title()}",
+                        "",
+                    ]
+                )
+
+        # Single Command Execution
+        lines.extend(
+            [
+                "---",
+                "",
+                "## 🚀 Ready to Run?",
+                "",
+                "I've analyzed your project and created comprehensive test suites.",
+                "",
+                "### Execute All Tests",
+                "",
+                "```bash",
+                f"cd {summary.project_path}",
+                "e2e run",
+                "```",
+                "",
+                "### Or Execute with Options",
+                "",
+                "```bash",
+                "# Run specific service",
+                f"e2e run --service {summary.tech_stack.get(list(summary.tech_stack.keys())[0], {}).get('name', 'service')}"
+                if summary.tech_stack
+                else "e2e run --service <service-name>",
+                "",
+                "# Run with verbose output",
+                "e2e run --verbose",
+                "",
+                "# Generate new tests if code changed",
+                "e2e generate-tests --force",
+                "```",
+                "",
+            ]
+        )
+
+        # Quick Reference
+        lines.extend(
+            [
+                "### 📖 Quick Reference",
+                "",
+                "| Command | Description |",
+                "|---------|-------------|",
+                "| `e2e run` | Run all tests |",
+                "| `e2e run --service <name>` | Run tests for specific service |",
+                "| `e2e run --verbose` | Run with detailed output |",
+                "| `e2e observe` | Check for running services |",
+                "| `e2e manifest` | Re-scan project |",
+                "| `e2e generate-tests` | Regenerate test suites |",
+                "",
+            ]
+        )
+
+        # What's Next
+        lines.extend(
+            [
+                "### 🎯 What's Next?",
+                "",
+                "1. **Review the generated tests** in the `services/` directory",
+                "2. **Customize test data** in `data_schema.py` files",
+                "3. **Run the tests** with `e2e run`",
+                "4. **Add custom tests** for specific business logic",
+                "",
+                "### 📁 Generated Files",
+                "",
+                f"All test files have been generated in: `{summary.output_directory}`",
+                "",
+                "```",
+                summary.output_directory.name if summary.output_directory else "services",
+                "/",
+                "├── <service-name>/",
+                "│   ├── __init__.py",
+                "│   ├── data_schema.py       # DTOs and test data",
+                "│   ├── <service>_page.py    # Page objects",
+                "│   └── modules/",
+                "│       ├── _01_<flow>.py    # Flow tests",
+                "│       └── _99_validation.py # Validation tests",
+                "```",
+                "",
+                "---",
+                "",
+                "*This report was automatically generated by socialseed-e2e AI.*",
+                "",
+            ]
+        )
+
+        return "\n".join(lines)
+
+    def _get_flow_emoji(self, flow_type: str) -> str:
+        """Get emoji for flow type."""
+        emojis = {
+            "authentication": "🔐",
+            "crud": "📋",
+            "management": "⚙️",
+            "registration": "📝",
+            "checkout": "🛒",
+            "workflow": "🔄",
+            "custom": "📌",
+        }
+        return emojis.get(flow_type, "📌")
+
+    def _get_complexity_emoji(self, complexity: str) -> str:
+        """Get emoji for complexity level."""
+        emojis = {
+            "simple": "🟢",
+            "moderate": "🟡",
+            "complex": "🔴",
+        }
+        return emojis.get(complexity, "⚪")
+
+    def _print_cli_summary(self, summary: DiscoverySummary) -> None:
+        """Print a CLI summary of the discovery."""
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.table import Table
+
+        console = Console()
+
+        # Build the summary message
+        tech_info = ""
+        if summary.tech_stack:
+            tech_list = [
+                f"{info['framework']} ({info['language']})" for info in summary.tech_stack.values()
+            ]
+            tech_info = f" in {', '.join(set(tech_list))}"
+
+        # Main summary panel
+        message = (
+            f"I've analyzed your project. I found {summary.endpoints_count} REST "
+            f"endpoints{tech_info}.\n\n"
+            f"I've created {len(summary.flows_discovered)} complex business flows:\n"
+        )
+
+        for flow in summary.flows_discovered:
+            message += f"  • {flow.name} ({flow.endpoints_count} steps)\n"
+
+        message += (
+            f"\n📁 Generated {summary.tests_generated} test files in "
+            f"`{summary.output_directory.relative_to(summary.project_path)}`\n\n"
+            f"✅ Ready to run? Execute: `e2e run`"
+        )
+
+        console.print(Panel(message, title="🤖 AI Discovery Complete", border_style="green"))
+
+        # Statistics table
+        table = Table(title="Project Statistics")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Count", style="green")
+
+        table.add_row("Services", str(summary.services_count))
+        table.add_row("Endpoints", str(summary.endpoints_count))
+        table.add_row("DTOs/Models", str(summary.dtos_count))
+        table.add_row("Business Flows", str(len(summary.flows_discovered)))
+        table.add_row("Test Files", str(summary.tests_generated))
+
+        console.print(table)
+        console.print()
+
+        # Report location
+        report_path = self.output_dir / "DISCOVERY_REPORT.md"
+        console.print(f"📄 Full report saved to: {report_path}")
+        console.print()
+
+    def get_single_command(self) -> str:
+        """Get the single command to execute everything.
+
+        Returns:
+            Command string to execute all tests
+        """
+        return f"cd {self.project_root} && e2e run"
+
+
+def generate_discovery_report(
+    project_root: Path,
+    manifest: Optional[ProjectKnowledge] = None,
+    flows: Optional[List[Dict[str, Any]]] = None,
+    tests_generated: int = 0,
+    output_dir: Optional[Path] = None,
+) -> Path:
+    """Convenience function to generate a discovery report.
+
+    Args:
+        project_root: Root directory of the project
+        manifest: Project manifest
+        flows: Discovered flows
+        tests_generated: Number of test files generated
+        output_dir: Output directory for tests
+
+    Returns:
+        Path to the generated report
+    """
+    generator = DiscoveryReportGenerator(project_root)
+    return generator.generate_report(manifest, flows, tests_generated, output_dir)

--- a/tests/project_manifest/test_discovery_report.py
+++ b/tests/project_manifest/test_discovery_report.py
@@ -1,0 +1,182 @@
+"""Tests for AI Discovery Report Generator (Issue #187)."""
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from socialseed_e2e.project_manifest.discovery_report import (
+    DiscoveredFlow,
+    DiscoveryReportGenerator,
+    DiscoverySummary,
+    generate_discovery_report,
+)
+
+
+class TestDiscoveredFlow:
+    """Test DiscoveredFlow dataclass."""
+
+    def test_flow_creation(self):
+        """Test creating a DiscoveredFlow."""
+        flow = DiscoveredFlow(
+            name="User Authentication",
+            description="Login and registration flow",
+            endpoints_count=3,
+            flow_type="authentication",
+            complexity="simple",
+        )
+
+        assert flow.name == "User Authentication"
+        assert flow.description == "Login and registration flow"
+        assert flow.endpoints_count == 3
+        assert flow.flow_type == "authentication"
+        assert flow.complexity == "simple"
+
+
+class TestDiscoverySummary:
+    """Test DiscoverySummary dataclass."""
+
+    def test_summary_creation(self):
+        """Test creating a DiscoverySummary."""
+        summary = DiscoverySummary(
+            project_name="test-api",
+            project_path=Path("/test/project"),
+            analysis_timestamp=datetime(2026, 2, 8, 15, 30, 0),
+            tech_stack={"users": {"framework": "Spring", "language": "java"}},
+            services_count=2,
+            endpoints_count=15,
+            dtos_count=10,
+            flows_discovered=[],
+            tests_generated=5,
+            output_directory=Path("/test/project/services"),
+        )
+
+        assert summary.project_name == "test-api"
+        assert summary.services_count == 2
+        assert summary.endpoints_count == 15
+
+
+class TestDiscoveryReportGenerator:
+    """Test DiscoveryReportGenerator."""
+
+    @pytest.fixture
+    def generator(self, tmp_path):
+        return DiscoveryReportGenerator(tmp_path)
+
+    def test_init(self, generator, tmp_path):
+        """Test generator initialization."""
+        assert generator.project_root == tmp_path
+        assert generator.output_dir == tmp_path / ".e2e"
+        assert generator.output_dir.exists()
+
+    def test_calculate_complexity(self, generator):
+        """Test complexity calculation."""
+        # Simple flow (1-2 steps)
+        simple = {"steps": [{}, {}]}
+        assert generator._calculate_complexity(simple) == "simple"
+
+        # Moderate flow (3-4 steps)
+        moderate = {"steps": [{}, {}, {}]}
+        assert generator._calculate_complexity(moderate) == "moderate"
+
+        # Complex flow (5+ steps)
+        complex_flow = {"steps": [{}, {}, {}, {}, {}]}
+        assert generator._calculate_complexity(complex_flow) == "complex"
+
+    def test_get_flow_emoji(self, generator):
+        """Test flow emoji mapping."""
+        assert generator._get_flow_emoji("authentication") == "🔐"
+        assert generator._get_flow_emoji("crud") == "📋"
+        assert generator._get_flow_emoji("management") == "⚙️"
+        assert generator._get_flow_emoji("unknown") == "📌"
+
+    def test_get_complexity_emoji(self, generator):
+        """Test complexity emoji mapping."""
+        assert generator._get_complexity_emoji("simple") == "🟢"
+        assert generator._get_complexity_emoji("moderate") == "🟡"
+        assert generator._get_complexity_emoji("complex") == "🔴"
+        assert generator._get_complexity_emoji("unknown") == "⚪"
+
+    def test_build_markdown_content(self, generator):
+        """Test markdown content generation."""
+        summary = DiscoverySummary(
+            project_name="test-api",
+            project_path=Path("/test/project"),
+            analysis_timestamp=datetime(2026, 2, 8, 15, 30, 0),
+            tech_stack={"users": {"framework": "Spring", "language": "java"}},
+            services_count=2,
+            endpoints_count=15,
+            dtos_count=10,
+            flows_discovered=[
+                DiscoveredFlow(
+                    name="Auth Flow",
+                    description="Authentication",
+                    endpoints_count=3,
+                    flow_type="authentication",
+                    complexity="simple",
+                )
+            ],
+            tests_generated=5,
+            output_directory=Path("/test/project/services"),
+        )
+
+        content = generator._build_markdown_content(summary)
+
+        # Check key sections exist
+        assert "# 🔍 AI Discovery Report" in content
+        assert "test-api" in content
+        assert "Spring" in content
+        assert "Auth Flow" in content
+        assert "e2e run" in content
+
+    def test_get_single_command(self, generator, tmp_path):
+        """Test single command generation."""
+        command = generator.get_single_command()
+        assert f"cd {tmp_path}" in command
+        assert "e2e run" in command
+
+
+class TestGenerateDiscoveryReport:
+    """Test convenience function."""
+
+    def test_generate_report_function(self, tmp_path):
+        """Test the generate_discovery_report function."""
+        with patch.object(DiscoveryReportGenerator, "generate_report") as mock_generate:
+            mock_generate.return_value = tmp_path / ".e2e" / "DISCOVERY_REPORT.md"
+
+            result = generate_discovery_report(project_root=tmp_path, tests_generated=3)
+
+            assert mock_generate.called
+            assert result == tmp_path / ".e2e" / "DISCOVERY_REPORT.md"
+
+
+class TestIntegration:
+    """Integration tests."""
+
+    def test_end_to_end_report_generation(self, tmp_path):
+        """Test complete report generation flow."""
+        generator = DiscoveryReportGenerator(tmp_path)
+
+        # Create a mock summary
+        summary = DiscoverySummary(
+            project_name="integration-test",
+            project_path=tmp_path,
+            analysis_timestamp=datetime.now(),
+            tech_stack={},
+            services_count=1,
+            endpoints_count=5,
+            dtos_count=3,
+            flows_discovered=[],
+            tests_generated=2,
+            output_directory=tmp_path / "services",
+        )
+
+        # Generate markdown
+        content = generator._build_markdown_content(summary)
+
+        # Verify content
+        assert "integration-test" in content
+        assert "1" in content  # services count
+        assert "5" in content  # endpoints count
+        assert "e2e run" in content


### PR DESCRIPTION
Implements an AI Discovery Report that presents a Mental Map of the project after scanning, with a summary of what was discovered and a single command to execute all tests.

Features:
- DiscoveryReportGenerator: Creates comprehensive markdown reports
- Mental Map: Shows discovered endpoints, flows, and tech stack
- Statistics: Services, endpoints, DTOs, flows, test files count
- CLI summary: AI-like message summarizing the discovery
- Single command: e2e run to execute all discovered tests
- CLI command: e2e discover to generate report on demand

Integration:
- Auto-generates after e2e generate-tests
- Can be manually generated with e2e discover
- Cross-references with project manifest
- Saves to .e2e/DISCOVERY_REPORT.md

Output includes:
- Technology stack analysis
- Business flows discovered
- Project statistics
- Quick start commands
- Next steps and recommendations

Example output:
  I've analyzed your project. I found 15 REST endpoints in Java/Spring. I've created 3 complex user flows in your services/ folder. Ready to run?

New files:
- discovery_report.py: Core report generation
- test_discovery_report.py: Comprehensive tests
- ai-discovery-report.md: Complete documentation

Closes #187
