### PR TITLE
feat: Add WebSocket Testing Support (Issue #52)

### DIFF
--- a/docs/websocket-testing.md
+++ b/docs/websocket-testing.md
@@ -1,0 +1,776 @@
+# WebSocket Testing
+
+This document describes WebSocket testing support in socialseed-e2e, including setup, configuration, and best practices.
+
+## Overview
+
+socialseed-e2e provides comprehensive support for testing WebSocket APIs. The framework includes:
+
+- **BaseWebSocketPage**: Foundation class for WebSocket testing
+- **Connection Management**: Automatic connection handling with reconnection support
+- **Message Handling**: Send/receive messages with automatic JSON parsing
+- **Async Support**: Full async/await support for WebSocket operations
+- **Message History**: Track all sent and received messages
+- **Event Handlers**: Register callbacks for specific message types
+
+## Installation
+
+WebSocket support requires the `websockets` package:
+
+```bash
+pip install websockets
+```
+
+Or add to your project:
+
+```bash
+echo "websockets>=12.0" >> requirements.txt
+pip install -r requirements.txt
+```
+
+## Quick Start
+
+### Basic Connection
+
+```python
+import asyncio
+from socialseed_e2e import BaseWebSocketPage
+
+async def test_websocket():
+    # Create page
+    page = BaseWebSocketPage("wss://api.example.com/ws")
+    page.setup()
+
+    try:
+        # Connect
+        await page.connect()
+        print("Connected!")
+
+        # Send message
+        await page.send('{"action": "ping"}')
+
+        # Receive response
+        message = await page.receive()
+        print(f"Received: {message.data}")
+
+    finally:
+        # Cleanup
+        await page.disconnect()
+        page.teardown()
+
+# Run
+asyncio.run(test_websocket())
+```
+
+## Core Classes
+
+### BaseWebSocketPage
+
+Main class for WebSocket testing:
+
+```python
+from socialseed_e2e import BaseWebSocketPage, WebSocketConfig
+
+# With default configuration
+page = BaseWebSocketPage("wss://api.example.com/ws")
+
+# With custom configuration
+config = WebSocketConfig(
+    connect_timeout=10.0,
+    auto_reconnect=True,
+    max_reconnect_attempts=3,
+)
+page = BaseWebSocketPage("wss://api.example.com/ws", config=config)
+```
+
+### WebSocketConfig
+
+Configuration options:
+
+```python
+from socialseed_e2e import WebSocketConfig
+
+config = WebSocketConfig(
+    # Connection timeouts
+    connect_timeout=10.0,           # Connection timeout (seconds)
+    receive_timeout=30.0,           # Message receive timeout (seconds)
+
+    # Reconnection
+    auto_reconnect=True,            # Auto-reconnect on disconnect
+    max_reconnect_attempts=3,       # Max reconnection attempts
+    reconnect_delay=1.0,            # Initial delay between attempts
+
+    # Keep-alive
+    ping_interval=20.0,             # Ping interval (seconds)
+    ping_timeout=10.0,              # Pong response timeout (seconds)
+
+    # Protocol options
+    subprotocols=["chat", "json"],  # Subprotocols to negotiate
+    headers={"X-Custom": "value"},  # Custom headers for handshake
+)
+```
+
+### WebSocketMessage
+
+Represents a WebSocket message:
+
+```python
+message = await page.receive()
+
+# Properties
+print(message.data)           # Raw message data
+print(message.message_type)   # "text" or "binary"
+print(message.direction)      # "incoming" or "outgoing"
+print(message.timestamp)      # Unix timestamp
+
+# Methods
+if message.is_text:
+    data = message.json()     # Parse as JSON
+
+if message.is_binary:
+    binary_data = message.data  # Bytes
+```
+
+## Connection Management
+
+### Connecting
+
+```python
+# Simple connection
+await page.connect()
+
+# Check connection status
+if page.is_connected:
+    print("WebSocket is connected")
+
+# Connection with error handling
+from socialseed_e2e import WebSocketError
+
+try:
+    await page.connect()
+except WebSocketError as e:
+    print(f"Failed to connect: {e}")
+    print(f"URL: {e.url}")
+```
+
+### Disconnecting
+
+```python
+# Graceful disconnect
+await page.disconnect()
+
+# Forced disconnect (if needed)
+page._connected = False
+if page.websocket:
+    await page.websocket.close()
+```
+
+### Reconnection
+
+Enable automatic reconnection:
+
+```python
+config = WebSocketConfig(
+    auto_reconnect=True,
+    max_reconnect_attempts=3,
+    reconnect_delay=1.0,  # Initial delay (doubles with each attempt)
+)
+
+page = BaseWebSocketPage(url, config=config)
+await page.connect()
+
+# If connection drops, it will auto-reconnect
+```
+
+## Message Handling
+
+### Sending Messages
+
+```python
+# Send text
+await page.send("Hello, WebSocket!")
+
+# Send JSON (dict automatically serialized)
+await page.send({
+    "action": "subscribe",
+    "channel": "updates"
+})
+
+# Send binary
+await page.send(b"\x00\x01\x02\x03")
+```
+
+### Receiving Messages
+
+```python
+# Receive any message
+message = await page.receive()
+
+# Receive with timeout
+message = await page.receive(timeout=5.0)
+
+# Receive specific message type
+message = await page.receive(message_type="text")
+
+# Receive and parse JSON
+data = await page.receive_json()
+print(data["action"])
+```
+
+### Message Handlers
+
+Register callbacks for specific message types:
+
+```python
+# Decorator style
+@page.on_message("text")
+def handle_text(message):
+    print(f"Text message: {message.data}")
+
+@page.on_message("binary")
+async def handle_binary(message):
+    await process_binary(message.data)
+
+# Function style
+def handler(message):
+    print(f"Received: {message.data}")
+
+page.on_message("text", handler)
+
+# Handlers are called automatically when messages arrive
+# Run in background receive loop
+```
+
+### Waiting for Specific Messages
+
+```python
+# Wait for message matching predicate
+message = await page.wait_for_message(
+    lambda m: "success" in m.data,
+    timeout=10.0
+)
+
+# Wait for JSON with specific field
+message = await page.wait_for_message(
+    lambda m: m.json().get("type") == "notification"
+)
+
+# Wait for broadcast
+message = await page.wait_for_message(
+    lambda m: m.json().get("broadcast") == True
+)
+```
+
+## Message History
+
+### Tracking Messages
+
+All messages are automatically tracked:
+
+```python
+# Get all messages
+history = page.get_message_history()
+
+# Filter by direction
+incoming = page.get_message_history(direction="incoming")
+outgoing = page.get_message_history(direction="outgoing")
+
+# Filter by type
+text_messages = page.get_message_history(message_type="text")
+
+# Get recent messages only
+recent = page.get_message_history(limit=10)
+
+# Combined filters
+recent_incoming = page.get_message_history(
+    direction="incoming",
+    message_type="text",
+    limit=5
+)
+```
+
+### Clearing History
+
+```python
+# Clear message history
+page.clear_history()
+
+# Also clears connection logs
+page.connection_logs.clear()
+```
+
+## Assertions
+
+### Connection Assertions
+
+```python
+# Assert connected
+page.assert_connected()
+
+# Assert disconnected
+await page.disconnect()
+page.assert_disconnected()
+```
+
+### Message Count Assertions
+
+```python
+# Total messages
+page.assert_message_count(10)
+
+# By direction
+page.assert_message_count(5, direction="incoming")
+page.assert_message_count(5, direction="outgoing")
+
+# By type
+page.assert_message_count(8, message_type="text")
+page.assert_message_count(2, message_type="binary")
+
+# Combined
+page.assert_message_count(
+    3,
+    direction="incoming",
+    message_type="text"
+)
+```
+
+## Creating Service-Specific Pages
+
+Extend `BaseWebSocketPage` for your service:
+
+```python
+from socialseed_e2e import BaseWebSocketPage, WebSocketConfig
+
+class ChatServicePage(BaseWebSocketPage):
+    """Page for chat WebSocket service."""
+
+    def __init__(self, url="wss://chat.example.com/ws"):
+        config = WebSocketConfig(
+            ping_interval=20,
+            auto_reconnect=True,
+        )
+        super().__init__(url, config=config)
+        self.channels = []
+
+    async def subscribe(self, channel):
+        """Subscribe to a channel."""
+        await self.send({
+            "action": "subscribe",
+            "channel": channel
+        })
+        response = await self.receive_json()
+        if response.get("success"):
+            self.channels.append(channel)
+        return response
+
+    async def send_message(self, channel, message):
+        """Send a message to a channel."""
+        await self.send({
+            "action": "message",
+            "channel": channel,
+            "message": message
+        })
+        return await self.receive_json()
+
+    def assert_subscribed(self, channel):
+        """Assert subscription to channel."""
+        if channel not in self.channels:
+            raise AssertionError(
+                f"Not subscribed to '{channel}'"
+            )
+```
+
+## Testing Patterns
+
+### Basic Test Pattern
+
+```python
+import asyncio
+import pytest
+from socialseed_e2e import BaseWebSocketPage
+
+@pytest.mark.asyncio
+async def test_websocket_connection():
+    page = BaseWebSocketPage("wss://api.example.com/ws")
+    page.setup()
+
+    try:
+        # Connect
+        await page.connect()
+        page.assert_connected()
+
+        # Test ping/pong
+        await page.send('{"action": "ping"}')
+        response = await page.receive_json(timeout=5.0)
+        assert response["action"] == "pong"
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+```
+
+### Multi-Client Testing
+
+```python
+async def test_broadcast():
+    """Test broadcasting to multiple clients."""
+    # Create multiple clients
+    client1 = BaseWebSocketPage("wss://api.example.com/ws")
+    client2 = BaseWebSocketPage("wss://api.example.com/ws")
+
+    client1.setup()
+    client2.setup()
+
+    try:
+        # Connect both
+        await asyncio.gather(
+            client1.connect(),
+            client2.connect()
+        )
+
+        # Client1 sends broadcast
+        await client1.send({
+            "action": "broadcast",
+            "message": "Hello everyone!"
+        })
+
+        # Client2 receives broadcast
+        msg = await client2.wait_for_message(
+            lambda m: "broadcast" in m.data,
+            timeout=5.0
+        )
+        assert "Hello everyone!" in msg.data
+
+    finally:
+        await client1.disconnect()
+        await client2.disconnect()
+        client1.teardown()
+        client2.teardown()
+```
+
+### Error Testing
+
+```python
+async def test_error_handling():
+    """Test error responses."""
+    page = BaseWebSocketPage("wss://api.example.com/ws")
+    page.setup()
+
+    try:
+        await page.connect()
+
+        # Send invalid request
+        await page.send({"action": "invalid"})
+
+        # Wait for error
+        response = await page.receive_json()
+        assert response["type"] == "error"
+        assert "error" in response
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+```
+
+### Reconnection Testing
+
+```python
+async def test_reconnection():
+    """Test auto-reconnection."""
+    config = WebSocketConfig(
+        auto_reconnect=True,
+        max_reconnect_attempts=3,
+        reconnect_delay=0.5,
+    )
+
+    page = BaseWebSocketPage("wss://api.example.com/ws", config=config)
+    page.setup()
+
+    await page.connect()
+    assert page.is_connected
+
+    # Simulate disconnect (implementation depends on server)
+    # Server closes connection...
+
+    # Wait for reconnection
+    await asyncio.sleep(2)
+    assert page.is_connected  # Should reconnect
+
+    await page.disconnect()
+    page.teardown()
+```
+
+## Error Handling
+
+### WebSocketError
+
+```python
+from socialseed_e2e import WebSocketError
+
+try:
+    await page.connect()
+except WebSocketError as e:
+    print(f"Error: {e}")
+    print(f"URL: {e.url}")
+    print(f"Code: {e.code}")          # Close code
+    print(f"Reason: {e.reason}")      # Close reason
+
+try:
+    message = await page.receive(timeout=5.0)
+except WebSocketError as e:
+    if "timeout" in str(e).lower():
+        print("Receive timeout")
+    else:
+        raise
+```
+
+### Connection Errors
+
+```python
+# Handle connection refused
+page = BaseWebSocketPage("wss://invalid-server.com/ws")
+
+try:
+    await page.connect()
+except WebSocketError as e:
+    print(f"Connection failed: {e}")
+    # Server might be down
+
+# Handle SSL errors
+page = BaseWebSocketPage("wss://expired-cert.com/ws")
+
+try:
+    await page.connect()
+except WebSocketError as e:
+    print(f"SSL error: {e}")
+```
+
+## Best Practices
+
+### 1. Always Cleanup
+
+```python
+# Good: Always disconnect
+page = BaseWebSocketPage(url)
+page.setup()
+
+try:
+    await page.connect()
+    # ... tests ...
+finally:
+    await page.disconnect()
+    page.teardown()
+
+# Better: Use context manager (if available)
+async with WebSocketPage(url) as page:
+    # ... tests ...
+    pass  # Auto cleanup
+```
+
+### 2. Set Appropriate Timeouts
+
+```python
+# Good: Reasonable timeouts
+config = WebSocketConfig(
+    connect_timeout=10.0,   # 10 seconds for connection
+    receive_timeout=30.0,   # 30 seconds for messages
+)
+
+# Bad: Too short
+config = WebSocketConfig(
+    connect_timeout=0.5,    # Too short!
+    receive_timeout=1.0,    # Too short!
+)
+```
+
+### 3. Handle Reconnections Carefully
+
+```python
+# Good: Test both with and without reconnection
+async def test_with_reconnect():
+    config = WebSocketConfig(auto_reconnect=True)
+    page = BaseWebSocketPage(url, config=config)
+    # ... test reconnection ...
+
+async def test_without_reconnect():
+    config = WebSocketConfig(auto_reconnect=False)
+    page = BaseWebSocketPage(url, config=config)
+    # ... test normal behavior ...
+```
+
+### 4. Clean State Between Tests
+
+```python
+# Good: Clean state
+async def test1():
+    page = BaseWebSocketPage(url)
+    page.setup()
+    # ... test ...
+    await page.disconnect()
+    page.teardown()
+
+async def test2():
+    page = BaseWebSocketPage(url)  # Fresh instance
+    page.setup()
+    # ... test ...
+```
+
+### 5. Use Message History Wisely
+
+```python
+# Good: Clear history when needed
+async def test():
+    page = BaseWebSocketPage(url)
+    page.setup()
+
+    # Setup phase
+    await page.connect()
+    await page.send({"action": "login"})
+
+    # Clear before actual test
+    page.clear_history()
+
+    # Test phase
+    await page.send({"action": "test"})
+    page.assert_message_count(2)  # Only test messages
+```
+
+## Mock Server for Testing
+
+Use a mock server for reliable tests:
+
+```python
+# mock_server.py
+import asyncio
+import websockets
+import json
+
+async def handler(websocket, path):
+    async for message in websocket:
+        data = json.loads(message)
+
+        if data["action"] == "ping":
+            await websocket.send(json.dumps({"action": "pong"}))
+
+        elif data["action"] == "echo":
+            await websocket.send(json.dumps(data))
+
+        elif data["action"] == "error":
+            await websocket.send(json.dumps({
+                "type": "error",
+                "error": "Test error"
+            }))
+
+async def main():
+    server = await websockets.serve(handler, "localhost", 8765)
+    await server.wait_closed()
+
+asyncio.run(main())
+```
+
+## Examples
+
+See the `examples/websocket/` directory for complete examples:
+
+- `mock_server.py` - Mock WebSocket server
+- `chat_service_page.py` - Service page example
+- `test_websocket.py` - Complete test suite
+- `README.md` - Example documentation
+
+## Troubleshooting
+
+### Import Error
+
+```python
+# If you get: ImportError: websockets package is required
+# Install the package:
+pip install websockets
+```
+
+### Connection Timeout
+
+```python
+# Increase timeout
+config = WebSocketConfig(connect_timeout=30.0)
+page = BaseWebSocketPage(url, config=config)
+```
+
+### SSL Certificate Errors
+
+```python
+# For testing only - disable SSL verification
+import ssl
+import websockets
+
+ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+ssl_context.check_hostname = False
+ssl_context.verify_mode = ssl.CERT_NONE
+
+# Note: This is insecure, only for testing!
+```
+
+### Message Not Received
+
+```python
+# Check message is being sent
+await page.send(data)
+page.assert_message_count(1, direction="outgoing")
+
+# Increase receive timeout
+message = await page.receive(timeout=10.0)
+```
+
+## API Reference
+
+### BaseWebSocketPage
+
+| Method | Description |
+|--------|-------------|
+| `setup()` | Initialize the page |
+| `teardown()` | Cleanup resources |
+| `connect()` | Connect to WebSocket server |
+| `disconnect()` | Disconnect from server |
+| `send(data)` | Send a message |
+| `receive(timeout)` | Receive a message |
+| `receive_json(timeout)` | Receive and parse JSON |
+| `wait_for_message(predicate, timeout)` | Wait for specific message |
+| `on_message(type, handler)` | Register message handler |
+| `get_message_history(...)` | Get message history |
+| `clear_history()` | Clear history |
+| `assert_connected()` | Assert is connected |
+| `assert_disconnected()` | Assert is disconnected |
+| `assert_message_count(n, ...)` | Assert message count |
+
+### WebSocketConfig
+
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `connect_timeout` | 10.0 | Connection timeout (seconds) |
+| `receive_timeout` | 30.0 | Receive timeout (seconds) |
+| `auto_reconnect` | True | Auto-reconnect on disconnect |
+| `max_reconnect_attempts` | 3 | Max reconnection attempts |
+| `reconnect_delay` | 1.0 | Initial reconnection delay |
+| `ping_interval` | 20.0 | Ping interval (seconds) |
+| `ping_timeout` | 10.0 | Pong timeout (seconds) |
+| `subprotocols` | None | List of subprotocols |
+| `headers` | None | Custom headers |
+
+### WebSocketMessage
+
+| Property | Description |
+|----------|-------------|
+| `data` | Raw message content |
+| `message_type` | "text" or "binary" |
+| `direction` | "incoming" or "outgoing" |
+| `timestamp` | Unix timestamp |
+
+| Method | Description |
+|--------|-------------|
+| `json()` | Parse as JSON |
+
+## See Also
+
+- [Examples](../examples/websocket/)
+- [BasePage Documentation](base-page.md)
+- [gRPC Testing](grpc-testing.md)
+- [Testing Guide](testing-guide.md)

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -1,0 +1,239 @@
+# WebSocket Testing Example
+
+This example demonstrates how to use the socialseed-e2e framework for testing WebSocket APIs.
+
+## Files
+
+- `mock_server.py` - Mock WebSocket server for testing
+- `chat_service_page.py` - Example WebSocket page class
+- `test_websocket.py` - Example tests
+
+## Running the Example
+
+### 1. Install dependencies
+
+```bash
+pip install websockets
+```
+
+### 2. Start the mock server
+
+```bash
+python examples/websocket/mock_server.py
+```
+
+The server will start on `ws://localhost:8765`
+
+### 3. Run the tests
+
+In another terminal:
+
+```bash
+python examples/websocket/test_websocket.py
+```
+
+## Features Demonstrated
+
+### Connection Management
+
+```python
+from socialseed_e2e import BaseWebSocketPage
+
+page = BaseWebSocketPage("ws://localhost:8765")
+page.setup()
+
+# Connect
+await page.connect()
+page.assert_connected()
+
+# Disconnect
+await page.disconnect()
+page.assert_disconnected()
+
+page.teardown()
+```
+
+### Sending and Receiving Messages
+
+```python
+# Send text message
+await page.send("Hello, WebSocket!")
+
+# Send JSON message
+await page.send({"action": "subscribe", "channel": "general"})
+
+# Receive message
+message = await page.receive()
+print(message.data)
+
+# Receive and parse JSON
+data = await page.receive_json()
+```
+
+### Message Handlers
+
+```python
+# Register handler for specific message type
+@page.on_message("text")
+def handle_text(message):
+    print(f"Received: {message.data}")
+
+# Handler can be async too
+@page.on_message("binary")
+async def handle_binary(message):
+    await process_binary_data(message.data)
+```
+
+### Waiting for Specific Messages
+
+```python
+# Wait for message matching predicate
+message = await page.wait_for_message(
+    lambda m: "success" in m.data
+)
+
+# Wait for JSON message with specific field
+data = await page.wait_for_message(
+    lambda m: m.json().get("type") == "notification"
+)
+```
+
+### Message History
+
+```python
+# Get all messages
+history = page.get_message_history()
+
+# Filter by direction (incoming/outgoing)
+incoming = page.get_message_history(direction="incoming")
+
+# Filter by type
+json_messages = page.get_message_history(message_type="text")
+
+# Get recent messages only
+recent = page.get_message_history(limit=10)
+
+# Clear history
+page.clear_history()
+```
+
+### Assertions
+
+```python
+# Connection assertions
+page.assert_connected()
+page.assert_disconnected()
+
+# Message count assertions
+page.assert_message_count(5)
+page.assert_message_count(3, direction="outgoing")
+page.assert_message_count(2, message_type="text")
+```
+
+## Creating Custom WebSocket Pages
+
+Extend `BaseWebSocketPage` for service-specific testing:
+
+```python
+from socialseed_e2e import BaseWebSocketPage, WebSocketConfig
+
+class MyServicePage(BaseWebSocketPage):
+    def __init__(self, url="ws://api.example.com/ws"):
+        config = WebSocketConfig(
+            ping_interval=20,
+            auto_reconnect=True,
+        )
+        super().__init__(url, config=config)
+
+    async def login(self, username, password):
+        await self.send({
+            "action": "login",
+            "username": username,
+            "password": password
+        })
+        response = await self.receive_json()
+        self.access_token = response.get("token")
+        return response
+
+    async def subscribe(self, channel):
+        await self.send({
+            "action": "subscribe",
+            "channel": channel
+        })
+        return await self.receive_json()
+```
+
+## Configuration Options
+
+```python
+from socialseed_e2e import WebSocketConfig
+
+config = WebSocketConfig(
+    # Connection
+    connect_timeout=10.0,           # Connection timeout in seconds
+    receive_timeout=30.0,           # Message receive timeout
+
+    # Reconnection
+    auto_reconnect=True,            # Auto-reconnect on disconnect
+    max_reconnect_attempts=3,       # Max reconnection attempts
+    reconnect_delay=1.0,            # Initial delay between attempts
+
+    # Keep-alive
+    ping_interval=20.0,             # Ping interval in seconds
+    ping_timeout=10.0,              # Pong response timeout
+
+    # Protocol
+    subprotocols=["chat", "json"],  # Subprotocols to negotiate
+    headers={"Authorization": ...}, # Custom headers
+)
+
+page = BaseWebSocketPage("ws://api.example.com/ws", config=config)
+```
+
+## Error Handling
+
+```python
+from socialseed_e2e import WebSocketError
+
+try:
+    await page.connect()
+except WebSocketError as e:
+    print(f"Connection failed: {e}")
+    print(f"URL: {e.url}")
+    print(f"Code: {e.code}")
+    print(f"Reason: {e.reason}")
+
+try:
+    message = await page.receive(timeout=5.0)
+except WebSocketError as e:
+    print(f"Receive timeout: {e}")
+```
+
+## Testing Best Practices
+
+1. **Always cleanup**: Use try/finally or context managers to ensure disconnection
+2. **Set timeouts**: Always specify timeouts to prevent hanging tests
+3. **Use assertions**: Leverage built-in assertion methods
+4. **Handle reconnections**: Test both happy path and reconnection scenarios
+5. **Clean state**: Clear message history between test cases
+6. **Mock server**: Use mock server for reliable, repeatable tests
+
+## Running in CI/CD
+
+```yaml
+# Example GitHub Actions workflow
+- name: Start WebSocket Mock Server
+  run: |
+    python examples/websocket/mock_server.py &
+    sleep 2  # Wait for server to start
+
+- name: Run WebSocket Tests
+  run: |
+    python examples/websocket/test_websocket.py
+```
+
+## Next Steps
+
+- See `chat_service_page.py` for a complete service page example
+- Check `test_websocket.py` for comprehensive test patterns
+- Review the main framework documentation for advanced features

--- a/examples/websocket/chat_service_page.py
+++ b/examples/websocket/chat_service_page.py
@@ -1,0 +1,294 @@
+"""Test page for WebSocket chat service.
+
+This module provides a page object for testing the WebSocket chat service,
+extending BaseWebSocketPage with service-specific methods.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from socialseed_e2e.core.base_websocket_page import (
+    BaseWebSocketPage,
+    WebSocketConfig,
+    WebSocketMessage,
+)
+
+
+class ChatServicePage(BaseWebSocketPage):
+    """Page object for WebSocket chat service testing.
+
+    This class provides methods for interacting with a WebSocket chat service,
+    including sending messages, subscribing to channels, and handling broadcasts.
+
+    Example:
+        >>> page = ChatServicePage("ws://localhost:8765")
+        >>> page.setup()
+        >>> await page.connect()
+        >>> await page.subscribe("general")
+        >>> await page.send_message("Hello everyone!")
+        >>> message = await page.wait_for_message()
+        >>> print(f"Received: {message.data}")
+        >>> await page.disconnect()
+        >>> page.teardown()
+
+    Attributes:
+        subscribed_channels: List of subscribed channels
+        received_messages: Queue of received messages
+    """
+
+    def __init__(
+        self,
+        url: str = "ws://localhost:8765",
+        config: Optional[WebSocketConfig] = None,
+    ):
+        """Initialize the Chat service page.
+
+        Args:
+            url: WebSocket server URL
+            config: WebSocket configuration
+        """
+        super().__init__(url=url, config=config)
+        self.subscribed_channels: List[str] = []
+        self.received_messages: List[Dict[str, Any]] = []
+
+    def setup(self) -> "ChatServicePage":
+        """Set up the page.
+
+        Returns:
+            Self for method chaining
+        """
+        super().setup()
+        # Register message handler for incoming messages
+        self.on_message("text", self._handle_incoming_message)
+        return self
+
+    async def _handle_incoming_message(self, message: WebSocketMessage) -> None:
+        """Handle incoming messages.
+
+        Args:
+            message: Received WebSocket message
+        """
+        try:
+            data = message.json()
+            self.received_messages.append(data)
+        except Exception as e:
+            # Handle non-JSON messages
+            self.received_messages.append({"raw": message.data, "error": str(e)})
+
+    async def subscribe(self, channel: str) -> Dict[str, Any]:
+        """Subscribe to a chat channel.
+
+        Args:
+            channel: Channel name to subscribe to
+
+        Returns:
+            Server response
+        """
+        await self.send(
+            {
+                "action": "subscribe",
+                "channel": channel,
+            }
+        )
+
+        response = await self.receive_json(timeout=5.0)
+
+        if response.get("type") == "subscribed":
+            self.subscribed_channels.append(channel)
+
+        return response
+
+    async def send_message(
+        self, message: str, channel: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Send a chat message.
+
+        Args:
+            message: Message content
+            channel: Optional channel name (uses subscribed channel if not specified)
+
+        Returns:
+            Server response
+        """
+        data = {
+            "action": "echo",
+            "data": {
+                "message": message,
+                "channel": channel
+                or (
+                    self.subscribed_channels[0]
+                    if self.subscribed_channels
+                    else "general"
+                ),
+            },
+        }
+
+        await self.send(data)
+        return await self.receive_json(timeout=5.0)
+
+    async def broadcast(self, message: str) -> Dict[str, Any]:
+        """Broadcast a message to all clients.
+
+        Args:
+            message: Message to broadcast
+
+        Returns:
+            Server response with recipient count
+        """
+        await self.send(
+            {
+                "action": "broadcast",
+                "message": message,
+            }
+        )
+
+        return await self.receive_json(timeout=5.0)
+
+    async def wait_for_message(self, timeout: float = 10.0) -> Dict[str, Any]:
+        """Wait for a message from the server.
+
+        Args:
+            timeout: Timeout in seconds
+
+        Returns:
+            Received message data
+        """
+        message = await self.receive_json(timeout=timeout)
+        return message
+
+    async def simulate_delay(self, delay_ms: int = 1000) -> Dict[str, Any]:
+        """Simulate a delayed response.
+
+        Args:
+            delay_ms: Delay in milliseconds
+
+        Returns:
+            Server response
+        """
+        await self.send(
+            {
+                "action": "delay",
+                "delay_ms": delay_ms,
+            }
+        )
+
+        return await self.receive_json(timeout=(delay_ms / 1000) + 5.0)
+
+    async def trigger_error(self, error_message: str = "Test error") -> Dict[str, Any]:
+        """Trigger an error response.
+
+        Args:
+            error_message: Error message to send
+
+        Returns:
+            Error response
+        """
+        await self.send(
+            {
+                "action": "error",
+                "error_message": error_message,
+            }
+        )
+
+        return await self.receive_json(timeout=5.0)
+
+    def get_subscribed_channels(self) -> List[str]:
+        """Get list of subscribed channels.
+
+        Returns:
+            List of channel names
+        """
+        return self.subscribed_channels.copy()
+
+    def get_received_messages(self) -> List[Dict[str, Any]]:
+        """Get all received messages.
+
+        Returns:
+            List of received message data
+        """
+        return self.received_messages.copy()
+
+    def clear_received_messages(self) -> None:
+        """Clear received messages buffer."""
+        self.received_messages.clear()
+
+    def assert_subscribed_to(self, channel: str) -> None:
+        """Assert that subscribed to a specific channel.
+
+        Args:
+            channel: Channel name to check
+
+        Raises:
+            AssertionError: If not subscribed to channel
+        """
+        if channel not in self.subscribed_channels:
+            raise AssertionError(
+                f"Expected to be subscribed to '{channel}', but subscribed to: {self.subscribed_channels}"
+            )
+
+    def assert_received_message_count(self, expected: int) -> None:
+        """Assert number of received messages.
+
+        Args:
+            expected: Expected message count
+
+        Raises:
+            AssertionError: If count doesn't match
+        """
+        actual = len(self.received_messages)
+        if actual != expected:
+            raise AssertionError(
+                f"Expected {expected} received messages, but got {actual}"
+            )
+
+
+async def example_usage():
+    """Example usage of ChatServicePage."""
+    # Create page
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        # Connect to server
+        await page.connect()
+        print("✓ Connected to WebSocket server")
+
+        # Subscribe to channel
+        response = await page.subscribe("general")
+        print(f"✓ Subscribed: {response}")
+
+        # Send a message
+        response = await page.send_message("Hello, World!")
+        print(f"✓ Message sent: {response}")
+
+        # Check received messages
+        messages = page.get_received_messages()
+        print(f"✓ Received {len(messages)} messages")
+
+        # Broadcast
+        response = await page.broadcast("Important announcement!")
+        print(f"✓ Broadcast sent to {response.get('recipients', 0)} recipients")
+
+        # Assertions
+        page.assert_connected()
+        page.assert_subscribed_to("general")
+        print("✓ All assertions passed")
+
+    finally:
+        # Cleanup
+        await page.disconnect()
+        page.teardown()
+        print("✓ Disconnected")
+
+
+if __name__ == "__main__":
+    # Run example
+    print("WebSocket Chat Service Page Example")
+    print("Make sure the mock server is running: python mock_server.py")
+    print()
+
+    try:
+        asyncio.run(example_usage())
+    except Exception as e:
+        print(f"Error: {e}")
+        print("\nMake sure the mock WebSocket server is running!")

--- a/examples/websocket/mock_server.py
+++ b/examples/websocket/mock_server.py
@@ -1,0 +1,237 @@
+"""Mock WebSocket server for testing examples.
+
+This module provides a simple WebSocket echo server for testing purposes.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+try:
+    import websockets
+    from websockets.server import WebSocketServerProtocol
+
+    WEBSOCKET_AVAILABLE = True
+except ImportError:
+    WEBSOCKET_AVAILABLE = False
+    print("websockets package not installed. Install with: pip install websockets")
+
+logger = logging.getLogger(__name__)
+
+
+class MockWebSocketServer:
+    """Mock WebSocket server for testing.
+
+    Provides a simple echo server that can also simulate different scenarios
+    like delays, errors, and broadcasts.
+
+    Example:
+        >>> server = MockWebSocketServer("localhost", 8765)
+        >>> await server.start()
+        >>> # Run tests
+        >>> await server.stop()
+    """
+
+    def __init__(self, host: str = "localhost", port: int = 8765):
+        """Initialize mock server.
+
+        Args:
+            host: Host to bind to
+            port: Port to listen on
+        """
+        self.host = host
+        self.port = port
+        self.server = None
+        self.clients: set = set()
+        self.message_history: list = []
+        self.running = False
+
+    async def start(self) -> None:
+        """Start the WebSocket server."""
+        if not WEBSOCKET_AVAILABLE:
+            raise RuntimeError("websockets package required")
+
+        self.server = await websockets.serve(
+            self._handle_client,
+            self.host,
+            self.port,
+        )
+        self.running = True
+        logger.info(f"WebSocket server started at ws://{self.host}:{self.port}")
+
+    async def stop(self) -> None:
+        """Stop the WebSocket server."""
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()
+            self.running = False
+            logger.info("WebSocket server stopped")
+
+    async def _handle_client(
+        self, websocket: WebSocketServerProtocol, path: str
+    ) -> None:
+        """Handle client connection.
+
+        Args:
+            websocket: WebSocket connection
+            path: Connection path
+        """
+        self.clients.add(websocket)
+        client_id = id(websocket)
+        logger.info(f"Client {client_id} connected")
+
+        try:
+            async for message in websocket:
+                # Log received message
+                self.message_history.append(
+                    {
+                        "type": "received",
+                        "client_id": client_id,
+                        "message": message,
+                        "timestamp": asyncio.get_event_loop().time(),
+                    }
+                )
+
+                # Parse and process message
+                try:
+                    data = json.loads(message)
+                    response = await self._process_message(data, client_id)
+                except json.JSONDecodeError:
+                    response = {"error": "Invalid JSON", "received": message}
+
+                # Send response
+                response_str = json.dumps(response)
+                await websocket.send(response_str)
+
+                # Log sent message
+                self.message_history.append(
+                    {
+                        "type": "sent",
+                        "client_id": client_id,
+                        "message": response_str,
+                        "timestamp": asyncio.get_event_loop().time(),
+                    }
+                )
+
+        except websockets.exceptions.ConnectionClosed:
+            logger.info(f"Client {client_id} disconnected")
+        finally:
+            self.clients.discard(websocket)
+
+    async def _process_message(self, data: dict, client_id: int) -> dict:
+        """Process incoming message and generate response.
+
+        Args:
+            data: Parsed JSON message
+            client_id: Client identifier
+
+        Returns:
+            Response dictionary
+        """
+        action = data.get("action", "echo")
+
+        if action == "echo":
+            return {
+                "type": "echo",
+                "data": data.get("data"),
+                "client_id": client_id,
+            }
+
+        elif action == "subscribe":
+            channel = data.get("channel", "default")
+            return {
+                "type": "subscribed",
+                "channel": channel,
+                "client_id": client_id,
+            }
+
+        elif action == "broadcast":
+            # Broadcast to all clients
+            message = data.get("message", "")
+            await self._broadcast(message, exclude=client_id)
+            return {
+                "type": "broadcast_sent",
+                "message": message,
+                "recipients": len(self.clients) - 1,
+            }
+
+        elif action == "delay":
+            # Simulate processing delay
+            delay_ms = data.get("delay_ms", 1000)
+            await asyncio.sleep(delay_ms / 1000)
+            return {
+                "type": "delayed_response",
+                "delay_ms": delay_ms,
+            }
+
+        elif action == "error":
+            # Simulate error response
+            return {
+                "type": "error",
+                "error": data.get("error_message", "Simulated error"),
+                "code": data.get("error_code", 500),
+            }
+
+        else:
+            return {
+                "type": "unknown_action",
+                "action": action,
+                "supported_actions": [
+                    "echo",
+                    "subscribe",
+                    "broadcast",
+                    "delay",
+                    "error",
+                ],
+            }
+
+    async def _broadcast(self, message: str, exclude: Optional[int] = None) -> None:
+        """Broadcast message to all clients.
+
+        Args:
+            message: Message to broadcast
+            exclude: Client ID to exclude from broadcast
+        """
+        if not self.clients:
+            return
+
+        data = json.dumps({"type": "broadcast", "message": message})
+
+        for client in self.clients:
+            if exclude and id(client) == exclude:
+                continue
+            try:
+                await client.send(data)
+            except Exception as e:
+                logger.error(f"Failed to broadcast to client: {e}")
+
+    def get_message_history(self) -> list:
+        """Get message history."""
+        return self.message_history.copy()
+
+    def clear_history(self) -> None:
+        """Clear message history."""
+        self.message_history.clear()
+
+
+async def main():
+    """Run server for testing."""
+    logging.basicConfig(level=logging.INFO)
+
+    server = MockWebSocketServer("localhost", 8765)
+    await server.start()
+
+    print(f"WebSocket server running at ws://localhost:8765")
+    print("Press Ctrl+C to stop")
+
+    try:
+        await asyncio.Future()  # Run forever
+    except KeyboardInterrupt:
+        print("\nStopping server...")
+    finally:
+        await server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/websocket/test_websocket.py
+++ b/examples/websocket/test_websocket.py
@@ -1,0 +1,272 @@
+"""WebSocket test example.
+
+This module demonstrates how to write WebSocket tests using the framework.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from chat_service_page import ChatServicePage
+
+
+async def test_basic_connection():
+    """Test basic WebSocket connection."""
+    print("\n=== Test: Basic Connection ===")
+
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        # Connect
+        await page.connect()
+        page.assert_connected()
+        print("✓ Connected successfully")
+
+        # Disconnect
+        await page.disconnect()
+        page.assert_disconnected()
+        print("✓ Disconnected successfully")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        page.teardown()
+
+
+async def test_subscribe():
+    """Test channel subscription."""
+    print("\n=== Test: Channel Subscription ===")
+
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        await page.connect()
+
+        # Subscribe to channel
+        response = await page.subscribe("test-channel")
+
+        assert response.get("type") == "subscribed", (
+            f"Expected 'subscribed', got {response.get('type')}"
+        )
+        assert response.get("channel") == "test-channel"
+
+        page.assert_subscribed_to("test-channel")
+        print("✓ Subscribed to channel successfully")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+
+
+async def test_send_message():
+    """Test sending messages."""
+    print("\n=== Test: Send Message ===")
+
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        await page.connect()
+        await page.subscribe("general")
+
+        # Send message
+        response = await page.send_message("Hello, WebSocket!")
+
+        assert response.get("type") == "echo", (
+            f"Expected 'echo', got {response.get('type')}"
+        )
+        assert "data" in response
+        print("✓ Message sent and echoed successfully")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+
+
+async def test_broadcast():
+    """Test broadcasting messages."""
+    print("\n=== Test: Broadcast ===")
+
+    # Create two client pages
+    page1 = ChatServicePage("ws://localhost:8765")
+    page2 = ChatServicePage("ws://localhost:8765")
+
+    page1.setup()
+    page2.setup()
+
+    try:
+        # Connect both clients
+        await page1.connect()
+        await page2.connect()
+
+        # Subscribe both to same channel
+        await page1.subscribe("general")
+        await page2.subscribe("general")
+
+        # Page1 broadcasts
+        response = await page1.broadcast("Hello everyone!")
+
+        assert response.get("type") == "broadcast_sent"
+        print(f"✓ Broadcast sent to {response.get('recipients', 0)} recipients")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        await page1.disconnect()
+        await page2.disconnect()
+        page1.teardown()
+        page2.teardown()
+
+
+async def test_error_handling():
+    """Test error handling."""
+    print("\n=== Test: Error Handling ===")
+
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        await page.connect()
+
+        # Trigger error response
+        response = await page.trigger_error("Test error message")
+
+        assert response.get("type") == "error"
+        assert "error" in response
+        print("✓ Error response handled correctly")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+
+
+async def test_message_history():
+    """Test message history tracking."""
+    print("\n=== Test: Message History ===")
+
+    page = ChatServicePage("ws://localhost:8765")
+    page.setup()
+
+    try:
+        await page.connect()
+        await page.subscribe("general")
+
+        # Send multiple messages
+        await page.send_message("Message 1")
+        await page.send_message("Message 2")
+        await page.send_message("Message 3")
+
+        # Check message history
+        history = page.get_message_history()
+        print(f"✓ Message history contains {len(history)} messages")
+
+        # Check received messages
+        received = page.get_received_messages()
+        assert len(received) >= 3, f"Expected at least 3 messages, got {len(received)}"
+        print(f"✓ Received {len(received)} messages")
+
+        # Clear and verify
+        page.clear_received_messages()
+        assert len(page.get_received_messages()) == 0
+        print("✓ Message buffer cleared")
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Test failed: {e}")
+        return False
+
+    finally:
+        await page.disconnect()
+        page.teardown()
+
+
+async def run_all_tests():
+    """Run all WebSocket tests."""
+    print("=" * 50)
+    print("WebSocket Test Suite")
+    print("=" * 50)
+    print("\nMake sure the mock server is running:")
+    print("  python examples/websocket/mock_server.py")
+    print()
+
+    tests = [
+        test_basic_connection,
+        test_subscribe,
+        test_send_message,
+        test_broadcast,
+        test_error_handling,
+        test_message_history,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            result = await test()
+            results.append((test.__name__, result))
+        except Exception as e:
+            print(f"✗ {test.__name__} crashed: {e}")
+            results.append((test.__name__, False))
+
+    # Summary
+    print("\n" + "=" * 50)
+    print("Test Summary")
+    print("=" * 50)
+
+    passed = sum(1 for _, result in results if result)
+    failed = len(results) - passed
+
+    for name, result in results:
+        status = "✓ PASS" if result else "✗ FAIL"
+        print(f"  {status}: {name}")
+
+    print(f"\nTotal: {len(results)} tests")
+    print(f"  Passed: {passed}")
+    print(f"  Failed: {failed}")
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    try:
+        success = asyncio.run(run_all_tests())
+        sys.exit(0 if success else 1)
+    except KeyboardInterrupt:
+        print("\n\nTests interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n\nTest suite error: {e}")
+        print("\nMake sure the mock WebSocket server is running!")
+        print("  python examples/websocket/mock_server.py")
+        sys.exit(1)

--- a/src/socialseed_e2e/__init__.py
+++ b/src/socialseed_e2e/__init__.py
@@ -103,6 +103,19 @@ try:
 except ImportError:
     GRPC_AVAILABLE = False
 
+# Core - WebSocket Support
+try:
+    from socialseed_e2e.core.base_websocket_page import (
+        WEBSOCKET_AVAILABLE,
+        BaseWebSocketPage,
+        WebSocketConfig,
+        WebSocketError,
+        WebSocketLog,
+        WebSocketMessage,
+    )
+except ImportError:
+    WEBSOCKET_AVAILABLE = False
+
 # Utils - Pydantic helpers (universal for all languages)
 # New universal model; Field creators for different conventions
 # Naming conversion utilities; Serialization utilities
@@ -242,6 +255,13 @@ __all__ = [
     "BaseGrpcPage",
     "GrpcRetryConfig",
     "GrpcCallLog",
+    # Core - WebSocket Support
+    "BaseWebSocketPage",
+    "WebSocketConfig",
+    "WebSocketMessage",
+    "WebSocketLog",
+    "WebSocketError",
+    "WEBSOCKET_AVAILABLE",
     # Core - Models
     "ServiceConfig",
     "TestContext",

--- a/src/socialseed_e2e/core/__init__.py
+++ b/src/socialseed_e2e/core/__init__.py
@@ -6,7 +6,20 @@ Todo es agnóstico de servicios específicos.
 """
 
 from .base_page import BasePage
-from .config_loader import ApiConfigLoader, get_config, get_service_config, get_service_url
+from .base_websocket_page import (
+    WEBSOCKET_AVAILABLE,
+    BaseWebSocketPage,
+    WebSocketConfig,
+    WebSocketError,
+    WebSocketLog,
+    WebSocketMessage,
+)
+from .config_loader import (
+    ApiConfigLoader,
+    get_config,
+    get_service_config,
+    get_service_url,
+)
 from .headers import DEFAULT_BROWSER_HEADERS, DEFAULT_JSON_HEADERS, get_combined_headers
 from .interfaces import IServicePage, ITestModule
 from .loaders import ModuleLoader
@@ -17,11 +30,18 @@ from .test_orchestrator import TestOrchestrator
 __all__ = [
     # Clases principales
     "BasePage",
+    "BaseWebSocketPage",
     "ApiConfigLoader",
     "ModuleLoader",
     "TestOrchestrator",
     "ServiceConfig",
     "TestContext",
+    # WebSocket support
+    "WebSocketConfig",
+    "WebSocketMessage",
+    "WebSocketLog",
+    "WebSocketError",
+    "WEBSOCKET_AVAILABLE",
     # Parallel execution
     "ParallelConfig",
     "run_tests_parallel",

--- a/src/socialseed_e2e/core/base_websocket_page.py
+++ b/src/socialseed_e2e/core/base_websocket_page.py
@@ -1,0 +1,638 @@
+"""Base WebSocket page for testing WebSocket APIs.
+
+This module provides a BaseWebSocketPage class for testing WebSocket services,
+offering a similar interface to BasePage but adapted for WebSocket protocol.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+from socialseed_e2e.utils.state_management import DynamicStateMixin
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    import websockets
+
+    WEBSOCKET_AVAILABLE = True
+except ImportError:
+    WEBSOCKET_AVAILABLE = False
+    logger.warning(
+        "websockets package not installed. WebSocket testing will not be available."
+    )
+
+
+@dataclass
+class WebSocketConfig:
+    """Configuration for WebSocket connections.
+
+    Attributes:
+        connect_timeout: Connection timeout in seconds (default: 10)
+        receive_timeout: Timeout for receiving messages in seconds (default: 30)
+        auto_reconnect: Whether to auto-reconnect on disconnect (default: True)
+        max_reconnect_attempts: Maximum reconnection attempts (default: 3)
+        reconnect_delay: Initial delay between reconnection attempts in seconds (default: 1.0)
+        ping_interval: Interval for sending ping frames in seconds (default: 20)
+        ping_timeout: Timeout for pong response in seconds (default: 10)
+        subprotocols: List of subprotocols to negotiate (default: None)
+        headers: Additional headers for WebSocket handshake (default: None)
+    """
+
+    connect_timeout: float = 10.0
+    receive_timeout: float = 30.0
+    auto_reconnect: bool = True
+    max_reconnect_attempts: int = 3
+    reconnect_delay: float = 1.0
+    ping_interval: float = 20.0
+    ping_timeout: float = 10.0
+    subprotocols: Optional[List[str]] = None
+    headers: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class WebSocketMessage:
+    """Represents a WebSocket message.
+
+    Attributes:
+        data: Message data (string or bytes)
+        message_type: Type of message (text, binary, ping, pong, close)
+        timestamp: When the message was received/sent
+        direction: "incoming" or "outgoing"
+    """
+
+    data: Union[str, bytes]
+    message_type: str  # text, binary, ping, pong, close
+    timestamp: float = field(default_factory=time.time)
+    direction: str = "incoming"  # incoming or outgoing
+
+    @property
+    def is_text(self) -> bool:
+        """Check if message is text type."""
+        return self.message_type == "text"
+
+    @property
+    def is_binary(self) -> bool:
+        """Check if message is binary type."""
+        return self.message_type == "binary"
+
+    def json(self) -> Any:
+        """Parse message data as JSON.
+
+        Returns:
+            Parsed JSON data
+
+        Raises:
+            json.JSONDecodeError: If data is not valid JSON
+        """
+        if isinstance(self.data, bytes):
+            return json.loads(self.data.decode("utf-8"))
+        return json.loads(self.data)
+
+
+@dataclass
+class WebSocketLog:
+    """Log entry for WebSocket operations.
+
+    Attributes:
+        operation: Operation type (connect, disconnect, send, receive, error)
+        timestamp: When the operation occurred
+        duration_ms: Operation duration in milliseconds
+        message: Message data (if applicable)
+        error: Error message if operation failed
+    """
+
+    operation: str
+    timestamp: float = field(default_factory=time.time)
+    duration_ms: float = 0.0
+    message: Optional[WebSocketMessage] = None
+    error: Optional[str] = None
+
+
+class WebSocketError(Exception):
+    """Exception raised for WebSocket errors."""
+
+    def __init__(
+        self,
+        message: str,
+        url: Optional[str] = None,
+        code: Optional[int] = None,
+        reason: Optional[str] = None,
+    ):
+        """Initialize WebSocket error.
+
+        Args:
+            message: Error message
+            url: WebSocket URL
+            code: Close code (if connection closed)
+            reason: Close reason (if connection closed)
+        """
+        super().__init__(message)
+        self.url = url
+        self.code = code
+        self.reason = reason
+
+
+class BaseWebSocketPage(DynamicStateMixin):
+    """Base page for testing WebSocket APIs.
+
+    This class provides a foundation for creating WebSocket service pages,
+    similar to BasePage for REST APIs. It handles connection management,
+    message handling, and logging.
+
+    Example:
+        >>> page = BaseWebSocketPage("wss://api.example.com/ws")
+        >>> page.setup()
+        >>> await page.connect()
+        >>> await page.send({"action": "subscribe", "channel": "updates"})
+        >>> message = await page.receive()
+        >>> print(message.data)
+        >>> await page.disconnect()
+        >>> page.teardown()
+
+    Attributes:
+        url: WebSocket URL
+        config: WebSocket configuration
+        websocket: Active WebSocket connection
+        message_history: Queue of recent messages
+        connection_logs: List of connection events
+    """
+
+    def __init__(
+        self,
+        url: str,
+        config: Optional[WebSocketConfig] = None,
+        max_message_history: int = 100,
+    ) -> None:
+        """Initialize the BaseWebSocketPage.
+
+        Args:
+            url: WebSocket URL (e.g., "wss://api.example.com/ws")
+            config: WebSocket configuration (uses defaults if not provided)
+            max_message_history: Maximum number of messages to keep in history
+
+        Raises:
+            ImportError: If websockets package is not installed
+        """
+        if not WEBSOCKET_AVAILABLE:
+            raise ImportError(
+                "websockets package is required for WebSocket testing. "
+                "Install with: pip install websockets"
+            )
+
+        super().__init__()
+
+        self.url: str = url
+        self.config: WebSocketConfig = config or WebSocketConfig()
+        self.max_message_history: int = max_message_history
+
+        # Connection state
+        self.websocket: Optional[Any] = None
+        self._connected: bool = False
+        self._connection_time: Optional[float] = None
+
+        # Message handling
+        self.message_history: deque = deque(maxlen=max_message_history)
+        self._pending_messages: asyncio.Queue = asyncio.Queue()
+        self._message_handlers: Dict[str, List[Callable]] = {}
+
+        # Logging
+        self.connection_logs: List[WebSocketLog] = []
+        self._receive_task: Optional[asyncio.Task] = None
+
+        # Reconnection state
+        self._reconnect_attempts: int = 0
+        self._should_reconnect: bool = False
+
+    def setup(self) -> None:
+        """Setup the WebSocket page."""
+        logger.info(f"Setting up WebSocket page for {self.url}")
+
+    def teardown(self) -> None:
+        """Teardown the WebSocket page and close connection."""
+        logger.info(f"Tearing down WebSocket page for {self.url}")
+        if self._connected:
+            asyncio.get_event_loop().run_until_complete(self.disconnect())
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if WebSocket is connected."""
+        return self._connected and self.websocket is not None
+
+    async def connect(self) -> None:
+        """Connect to WebSocket server.
+
+        Raises:
+            WebSocketError: If connection fails
+        """
+        if self.is_connected:
+            logger.warning("Already connected to WebSocket")
+            return
+
+        start_time = time.time()
+        try:
+            extra_headers = self.config.headers or {}
+
+            self.websocket = await websockets.connect(
+                self.url,
+                subprotocols=self.config.subprotocols,
+                extra_headers=extra_headers,
+                ping_interval=self.config.ping_interval,
+                ping_timeout=self.config.ping_timeout,
+                close_timeout=self.config.connect_timeout,
+            )
+
+            self._connected = True
+            self._connection_time = time.time()
+            self._reconnect_attempts = 0
+
+            duration_ms = (time.time() - start_time) * 1000
+            log = WebSocketLog(
+                operation="connect",
+                duration_ms=duration_ms,
+            )
+            self.connection_logs.append(log)
+
+            # Start message receiver
+            self._receive_task = asyncio.create_task(self._receive_loop())
+
+            logger.info(f"Connected to WebSocket at {self.url}")
+
+        except Exception as e:
+            duration_ms = (time.time() - start_time) * 1000
+            log = WebSocketLog(
+                operation="connect",
+                duration_ms=duration_ms,
+                error=str(e),
+            )
+            self.connection_logs.append(log)
+            raise WebSocketError(f"Failed to connect to {self.url}: {e}", url=self.url)
+
+    async def disconnect(self) -> None:
+        """Disconnect from WebSocket server."""
+        if not self.is_connected:
+            return
+
+        self._should_reconnect = False
+
+        # Stop receive loop
+        if self._receive_task:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+            self._receive_task = None
+
+        start_time = time.time()
+        try:
+            if self.websocket:
+                await self.websocket.close()
+                self.websocket = None
+
+            self._connected = False
+
+            duration_ms = (time.time() - start_time) * 1000
+            log = WebSocketLog(
+                operation="disconnect",
+                duration_ms=duration_ms,
+            )
+            self.connection_logs.append(log)
+
+            logger.info(f"Disconnected from WebSocket at {self.url}")
+
+        except Exception as e:
+            duration_ms = (time.time() - start_time) * 1000
+            log = WebSocketLog(
+                operation="disconnect",
+                duration_ms=duration_ms,
+                error=str(e),
+            )
+            self.connection_logs.append(log)
+
+    async def send(self, data: Union[str, bytes, dict]) -> None:
+        """Send a message through WebSocket.
+
+        Args:
+            data: Message data (string, bytes, or dict that will be JSON-encoded)
+
+        Raises:
+            WebSocketError: If not connected or send fails
+        """
+        if not self.is_connected:
+            raise WebSocketError("Not connected to WebSocket", url=self.url)
+
+        start_time = time.time()
+        try:
+            # Convert dict to JSON string
+            if isinstance(data, dict):
+                data = json.dumps(data)
+
+            if isinstance(data, str):
+                await self.websocket.send(data)
+                message = WebSocketMessage(
+                    data=data, message_type="text", direction="outgoing"
+                )
+            else:
+                await self.websocket.send(data)
+                message = WebSocketMessage(
+                    data=data, message_type="binary", direction="outgoing"
+                )
+
+            duration_ms = (time.time() - start_time) * 1000
+            log = WebSocketLog(
+                operation="send",
+                duration_ms=duration_ms,
+                message=message,
+            )
+            self.connection_logs.append(log)
+            self.message_history.append(message)
+
+            logger.debug(
+                f"Sent message: {data[:100] if isinstance(data, str) else 'binary'}"
+            )
+
+        except Exception as e:
+            raise WebSocketError(f"Failed to send message: {e}", url=self.url)
+
+    async def receive(
+        self,
+        timeout: Optional[float] = None,
+        message_type: Optional[str] = None,
+    ) -> WebSocketMessage:
+        """Receive a message from WebSocket.
+
+        Args:
+            timeout: Timeout in seconds (uses config.receive_timeout if not specified)
+            message_type: Filter by message type (text, binary, etc.)
+
+        Returns:
+            WebSocketMessage: Received message
+
+        Raises:
+            WebSocketError: If receive fails or times out
+        """
+        if not self.is_connected:
+            raise WebSocketError("Not connected to WebSocket", url=self.url)
+
+        timeout = timeout or self.config.receive_timeout
+
+        try:
+            # Wait for message with timeout
+            message = await asyncio.wait_for(
+                self._pending_messages.get(),
+                timeout=timeout,
+            )
+
+            # Filter by message type if specified
+            if message_type and message.message_type != message_type:
+                # Put message back and wait for next
+                await self._pending_messages.put(message)
+                return await self.receive(timeout, message_type)
+
+            return message
+
+        except asyncio.TimeoutError:
+            raise WebSocketError(
+                f"Timeout waiting for message after {timeout}s",
+                url=self.url,
+            )
+
+    async def receive_json(self, timeout: Optional[float] = None) -> Any:
+        """Receive a message and parse as JSON.
+
+        Args:
+            timeout: Timeout in seconds
+
+        Returns:
+            Parsed JSON data
+        """
+        message = await self.receive(timeout=timeout, message_type="text")
+        return message.json()
+
+    async def _receive_loop(self) -> None:
+        """Background task to continuously receive messages."""
+        try:
+            while self.is_connected:
+                try:
+                    message_data = await self.websocket.recv()
+
+                    if isinstance(message_data, str):
+                        message = WebSocketMessage(
+                            data=message_data,
+                            message_type="text",
+                            direction="incoming",
+                        )
+                    else:
+                        message = WebSocketMessage(
+                            data=message_data,
+                            message_type="binary",
+                            direction="incoming",
+                        )
+
+                    # Add to history
+                    self.message_history.append(message)
+
+                    # Log
+                    log = WebSocketLog(
+                        operation="receive",
+                        message=message,
+                    )
+                    self.connection_logs.append(log)
+
+                    # Add to pending queue for receive() calls
+                    await self._pending_messages.put(message)
+
+                    # Trigger handlers
+                    await self._trigger_handlers(message)
+
+                except websockets.exceptions.ConnectionClosed as e:
+                    logger.info(f"WebSocket connection closed: {e}")
+                    self._connected = False
+
+                    # Attempt reconnection if configured
+                    if self.config.auto_reconnect and self._should_reconnect:
+                        await self._attempt_reconnect()
+                    break
+
+        except asyncio.CancelledError:
+            logger.debug("Receive loop cancelled")
+            raise
+
+    async def _attempt_reconnect(self) -> None:
+        """Attempt to reconnect to WebSocket server."""
+        while (
+            self._reconnect_attempts < self.config.max_reconnect_attempts
+            and self._should_reconnect
+        ):
+            self._reconnect_attempts += 1
+            delay = self.config.reconnect_delay * (2 ** (self._reconnect_attempts - 1))
+
+            logger.info(
+                f"Attempting reconnect {self._reconnect_attempts}/{self.config.max_reconnect_attempts} in {delay}s"
+            )
+            await asyncio.sleep(delay)
+
+            try:
+                await self.connect()
+                logger.info("Reconnected successfully")
+                return
+            except Exception as e:
+                logger.warning(f"Reconnection attempt failed: {e}")
+
+        logger.error("Max reconnection attempts reached")
+
+    async def _trigger_handlers(self, message: WebSocketMessage) -> None:
+        """Trigger registered message handlers."""
+        handlers = self._message_handlers.get(message.message_type, [])
+        for handler in handlers:
+            try:
+                if asyncio.iscoroutinefunction(handler):
+                    await handler(message)
+                else:
+                    handler(message)
+            except Exception as e:
+                logger.error(f"Error in message handler: {e}")
+
+    def on_message(self, message_type: str, handler: Callable) -> Callable:
+        """Register a message handler.
+
+        Args:
+            message_type: Type of message to handle (text, binary, etc.)
+            handler: Callback function to handle messages
+
+        Returns:
+            The handler function (for use as decorator)
+        """
+        if message_type not in self._message_handlers:
+            self._message_handlers[message_type] = []
+        self._message_handlers[message_type].append(handler)
+        return handler
+
+    def get_message_history(
+        self,
+        direction: Optional[str] = None,
+        message_type: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[WebSocketMessage]:
+        """Get filtered message history.
+
+        Args:
+            direction: Filter by direction ("incoming" or "outgoing")
+            message_type: Filter by message type
+            limit: Maximum number of messages to return
+
+        Returns:
+            List of WebSocketMessage objects
+        """
+        messages = list(self.message_history)
+
+        if direction:
+            messages = [m for m in messages if m.direction == direction]
+
+        if message_type:
+            messages = [m for m in messages if m.message_type == message_type]
+
+        if limit:
+            messages = messages[-limit:]
+
+        return messages
+
+    async def wait_for_message(
+        self,
+        predicate: Callable[[WebSocketMessage], bool],
+        timeout: Optional[float] = None,
+    ) -> WebSocketMessage:
+        """Wait for a message matching a predicate.
+
+        Args:
+            predicate: Function that returns True when desired message is found
+            timeout: Timeout in seconds
+
+        Returns:
+            WebSocketMessage that matched the predicate
+
+        Raises:
+            WebSocketError: If timeout reached without match
+        """
+        timeout = timeout or self.config.receive_timeout
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            # Check existing messages
+            for message in self.message_history:
+                if predicate(message):
+                    return message
+
+            # Wait for new message
+            try:
+                message = await asyncio.wait_for(
+                    self._pending_messages.get(),
+                    timeout=1.0,
+                )
+                if predicate(message):
+                    return message
+            except asyncio.TimeoutError:
+                continue
+
+        raise WebSocketError(
+            f"Timeout waiting for matching message after {timeout}s",
+            url=self.url,
+        )
+
+    def assert_connected(self) -> None:
+        """Assert that WebSocket is connected.
+
+        Raises:
+            AssertionError: If not connected
+        """
+        if not self.is_connected:
+            raise AssertionError(
+                f"Expected WebSocket to be connected to {self.url}, but it's not"
+            )
+
+    def assert_disconnected(self) -> None:
+        """Assert that WebSocket is disconnected.
+
+        Raises:
+            AssertionError: If connected
+        """
+        if self.is_connected:
+            raise AssertionError(
+                f"Expected WebSocket to be disconnected, but it's connected to {self.url}"
+            )
+
+    def assert_message_count(
+        self,
+        expected: int,
+        direction: Optional[str] = None,
+        message_type: Optional[str] = None,
+    ) -> None:
+        """Assert message count in history.
+
+        Args:
+            expected: Expected number of messages
+            direction: Filter by direction
+            message_type: Filter by message type
+
+        Raises:
+            AssertionError: If count doesn't match
+        """
+        messages = self.get_message_history(
+            direction=direction, message_type=message_type
+        )
+        actual = len(messages)
+        if actual != expected:
+            raise AssertionError(
+                f"Expected {expected} messages, but got {actual}. "
+                f"Filters: direction={direction}, type={message_type}"
+            )
+
+    def clear_history(self) -> None:
+        """Clear message history."""
+        self.message_history.clear()

--- a/tests/unit/core/test_websocket_page.py
+++ b/tests/unit/core/test_websocket_page.py
@@ -1,0 +1,335 @@
+"""Tests for WebSocket page implementation."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from socialseed_e2e.core.base_websocket_page import (
+    WEBSOCKET_AVAILABLE,
+    WebSocketConfig,
+    WebSocketError,
+    WebSocketLog,
+    WebSocketMessage,
+)
+
+# Skip all tests if websockets not available
+pytestmark = pytest.mark.skipif(
+    not WEBSOCKET_AVAILABLE,
+    reason="websockets package not installed",
+)
+
+
+class TestWebSocketConfig:
+    """Test WebSocketConfig dataclass."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = WebSocketConfig()
+
+        assert config.connect_timeout == 10.0
+        assert config.receive_timeout == 30.0
+        assert config.auto_reconnect is True
+        assert config.max_reconnect_attempts == 3
+        assert config.reconnect_delay == 1.0
+        assert config.ping_interval == 20.0
+        assert config.ping_timeout == 10.0
+        assert config.subprotocols is None
+        assert config.headers is None
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = WebSocketConfig(
+            connect_timeout=5.0,
+            receive_timeout=15.0,
+            auto_reconnect=False,
+            max_reconnect_attempts=5,
+            reconnect_delay=2.0,
+            ping_interval=10.0,
+            ping_timeout=5.0,
+            subprotocols=["chat", "json"],
+            headers={"Authorization": "Bearer token"},
+        )
+
+        assert config.connect_timeout == 5.0
+        assert config.receive_timeout == 15.0
+        assert config.auto_reconnect is False
+        assert config.max_reconnect_attempts == 5
+        assert config.reconnect_delay == 2.0
+        assert config.ping_interval == 10.0
+        assert config.ping_timeout == 5.0
+        assert config.subprotocols == ["chat", "json"]
+        assert config.headers == {"Authorization": "Bearer token"}
+
+
+class TestWebSocketMessage:
+    """Test WebSocketMessage dataclass."""
+
+    def test_text_message(self):
+        """Test text message creation."""
+        msg = WebSocketMessage(
+            data='{"action": "ping"}',
+            message_type="text",
+            direction="outgoing",
+        )
+
+        assert msg.data == '{"action": "ping"}'
+        assert msg.message_type == "text"
+        assert msg.direction == "outgoing"
+        assert msg.is_text is True
+        assert msg.is_binary is False
+
+    def test_binary_message(self):
+        """Test binary message creation."""
+        msg = WebSocketMessage(
+            data=b"\x00\x01\x02",
+            message_type="binary",
+            direction="incoming",
+        )
+
+        assert msg.data == b"\x00\x01\x02"
+        assert msg.message_type == "binary"
+        assert msg.direction == "incoming"
+        assert msg.is_text is False
+        assert msg.is_binary is True
+
+    def test_json_parsing(self):
+        """Test JSON parsing from text message."""
+        msg = WebSocketMessage(
+            data='{"action": "test", "value": 123}',
+            message_type="text",
+        )
+
+        data = msg.json()
+        assert data["action"] == "test"
+        assert data["value"] == 123
+
+    def test_json_parsing_binary(self):
+        """Test JSON parsing from binary message."""
+        msg = WebSocketMessage(
+            data=b'{"action": "test"}',
+            message_type="binary",
+        )
+
+        data = msg.json()
+        assert data["action"] == "test"
+
+
+class TestWebSocketLog:
+    """Test WebSocketLog dataclass."""
+
+    def test_log_creation(self):
+        """Test log entry creation."""
+        msg = WebSocketMessage(data="test", message_type="text")
+        log = WebSocketLog(
+            operation="send",
+            duration_ms=100.0,
+            message=msg,
+        )
+
+        assert log.operation == "send"
+        assert log.duration_ms == 100.0
+        assert log.message == msg
+        assert log.error is None
+
+    def test_error_log(self):
+        """Test error log entry."""
+        log = WebSocketLog(
+            operation="connect",
+            duration_ms=5000.0,
+            error="Connection refused",
+        )
+
+        assert log.operation == "connect"
+        assert log.error == "Connection refused"
+        assert log.message is None
+
+
+class TestWebSocketError:
+    """Test WebSocketError exception."""
+
+    def test_basic_error(self):
+        """Test basic error creation."""
+        error = WebSocketError("Connection failed")
+
+        assert str(error) == "Connection failed"
+        assert error.url is None
+        assert error.code is None
+        assert error.reason is None
+
+    def test_error_with_context(self):
+        """Test error with full context."""
+        error = WebSocketError(
+            message="Connection closed",
+            url="ws://example.com/ws",
+            code=1006,
+            reason="Abnormal closure",
+        )
+
+        assert "Connection closed" in str(error)
+        assert error.url == "ws://example.com/ws"
+        assert error.code == 1006
+        assert error.reason == "Abnormal closure"
+
+
+@pytest.mark.asyncio
+class TestBaseWebSocketPageUnit:
+    """Unit tests for BaseWebSocketPage (no connection)."""
+
+    def test_initialization(self):
+        """Test page initialization."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+
+        assert page.url == "ws://localhost:8765"
+        assert page.config is not None
+        assert page.is_connected is False
+        assert len(page.message_history) == 0
+        assert len(page.connection_logs) == 0
+
+    def test_initialization_with_config(self):
+        """Test page initialization with custom config."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        config = WebSocketConfig(connect_timeout=5.0)
+        page = BaseWebSocketPage("ws://localhost:8765", config=config)
+
+        assert page.config.connect_timeout == 5.0
+
+    def test_setup_teardown(self):
+        """Test setup and teardown."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+
+        page.setup()
+        assert page is not None
+
+        page.teardown()
+        # Should not raise even if not connected
+
+    def test_not_connected_assertions(self):
+        """Test assertions when not connected."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+        page.setup()
+
+        # assert_disconnected should pass when not connected
+        page.assert_disconnected()
+
+        # assert_connected should fail when not connected
+        with pytest.raises(AssertionError):
+            page.assert_connected()
+
+    def test_message_history_operations(self):
+        """Test message history operations."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+
+        # Add some messages manually
+        page.message_history.append(
+            WebSocketMessage(data="msg1", message_type="text", direction="incoming")
+        )
+        page.message_history.append(
+            WebSocketMessage(data="msg2", message_type="text", direction="outgoing")
+        )
+        page.message_history.append(
+            WebSocketMessage(data=b"bin", message_type="binary", direction="incoming")
+        )
+
+        # Get all messages
+        all_msgs = page.get_message_history()
+        assert len(all_msgs) == 3
+
+        # Filter by direction
+        incoming = page.get_message_history(direction="incoming")
+        assert len(incoming) == 2
+
+        outgoing = page.get_message_history(direction="outgoing")
+        assert len(outgoing) == 1
+
+        # Filter by type
+        text_msgs = page.get_message_history(message_type="text")
+        assert len(text_msgs) == 2
+
+        binary_msgs = page.get_message_history(message_type="binary")
+        assert len(binary_msgs) == 1
+
+        # Get recent with limit
+        recent = page.get_message_history(limit=2)
+        assert len(recent) == 2
+
+        # Clear history
+        page.clear_history()
+        assert len(page.get_message_history()) == 0
+
+    def test_message_count_assertions(self):
+        """Test message count assertions."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+
+        # Add messages
+        page.message_history.append(
+            WebSocketMessage(data="msg1", message_type="text", direction="incoming")
+        )
+        page.message_history.append(
+            WebSocketMessage(data="msg2", message_type="text", direction="outgoing")
+        )
+
+        # Total count
+        page.assert_message_count(2)
+
+        # By direction
+        page.assert_message_count(1, direction="incoming")
+        page.assert_message_count(1, direction="outgoing")
+
+        # Wrong count should raise
+        with pytest.raises(AssertionError):
+            page.assert_message_count(5)
+
+    def test_on_message_handler_registration(self):
+        """Test message handler registration."""
+        from socialseed_e2e.core.base_websocket_page import BaseWebSocketPage
+
+        page = BaseWebSocketPage("ws://localhost:8765")
+
+        # Register handler
+        def handler(msg):
+            pass
+
+        result = page.on_message("text", handler)
+
+        # Should return the handler
+        assert result == handler
+
+        # Handler should be registered
+        assert "text" in page._message_handlers
+        assert handler in page._message_handlers["text"]
+
+    def test_import_availability(self):
+        """Test that WebSocket classes can be imported."""
+        from socialseed_e2e import (
+            WEBSOCKET_AVAILABLE,
+            WebSocketConfig,
+            WebSocketMessage,
+            WebSocketLog,
+            WebSocketError,
+        )
+
+        # Classes should be importable
+        assert WebSocketConfig is not None
+        assert WebSocketMessage is not None
+        assert WebSocketLog is not None
+        assert WebSocketError is not None
+
+        # WEBSOCKET_AVAILABLE should be a boolean
+        assert isinstance(WEBSOCKET_AVAILABLE, bool)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Extend framework to test WebSocket APIs with comprehensive support for connection management, message handling, and testing utilities.

Features:
- BaseWebSocketPage: Main class for WebSocket testing with async support
- WebSocketConfig: Configuration for connections (timeouts, reconnection, etc.)
- WebSocketMessage: Representation of messages with JSON parsing
- WebSocketLog: Comprehensive operation logging
- WebSocketError: Detailed error handling with context

Connection Management:
- Async connect/disconnect with timeout support
- Auto-reconnection with configurable attempts and backoff
- Connection state tracking and assertions
- Ping/pong keep-alive support

Message Handling:
- Send/receive text and binary messages
- Automatic JSON serialization/deserialization
- Message history tracking with filters
- Event handlers for specific message types
- Wait for messages matching predicates

Testing Utilities:
- Built-in assertions (connected, message count, etc.)
- Message filtering by direction and type
- History management and clearing
- Service-specific page extension pattern

Documentation:
- Complete guide in docs/websocket-testing.md
- API reference with all classes and methods
- Usage examples and best practices
- Troubleshooting section

Examples:
- Mock WebSocket server for testing
- Chat service page implementation
- Complete test suite demonstrating patterns
- README with setup instructions

Tests:
- 18 unit tests for WebSocket functionality
- Tests for config, messages, logs, errors
- Integration with existing test suite
- 105 total core tests passing

Files Added:
- src/socialseed_e2e/core/base_websocket_page.py
- docs/websocket-testing.md
- examples/websocket/mock_server.py
- examples/websocket/chat_service_page.py
- examples/websocket/test_websocket.py
- examples/websocket/README.md
- tests/unit/core/test_websocket_page.py

Files Modified:
- src/socialseed_e2e/core/__init__.py (exports)
- src/socialseed_e2e/__init__.py (public exports)

Dependencies:
- websockets>=12.0 (optional, for WebSocket support)

Usage:
  from socialseed_e2e import BaseWebSocketPage

  page = BaseWebSocketPage("wss://api.example.com/ws") page.setup() await page.connect() await page.send({"action": "ping"}) message = await page.receive() await page.disconnect() page.teardown()

Resolves #52
