### PR TITLE
infra(#190): Provide Official Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# SocialSeed E2E - Official Docker Image
+# Provides a containerized environment for running E2E tests
+
+FROM python:3.11-slim
+
+LABEL maintainer="Dairon Pérez Frías <dairon.perezfrias@gmail.com>"
+LABEL description="SocialSeed E2E - Framework for testing REST APIs"
+LABEL version="0.1.2"
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Install system dependencies required by Playwright
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY pyproject.toml setup.py setup.cfg ./
+COPY src/ ./src/
+
+# Install the package
+RUN pip install --no-cache-dir .
+
+# Install Playwright browsers
+RUN playwright install chromium && \
+    playwright install-deps chromium
+
+# Create non-root user for security
+RUN useradd -m -u 1000 e2euser && \
+    chown -R e2euser:e2euser /app
+USER e2euser
+
+# Set the entrypoint to the e2e CLI
+ENTRYPOINT ["e2e"]
+
+# Default command shows help
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,92 @@ docker run --rm -v $(pwd):/app socialseed-e2e e2e run
 
 ---
 
+## 🐳 Docker Usage
+
+SocialSeed E2E provides an official Docker image for containerized test execution. This is ideal for CI/CD pipelines and environments where you want to avoid installing Python dependencies locally.
+
+### Building the Docker Image
+
+```bash
+# Clone or navigate to the project directory
+cd socialseed-e2e
+
+# Build the Docker image
+docker build -t socialseed-e2e .
+```
+
+### Running Tests with Docker
+
+#### Basic Usage
+
+```bash
+# Show help
+docker run --rm socialseed-e2e --help
+
+# Run all tests (mount your project directory)
+docker run --rm -v $(pwd):/app socialseed-e2e run
+
+# Run tests for a specific service
+docker run --rm -v $(pwd):/app socialseed-e2e run --service users-api
+
+# Run with verbose output
+docker run --rm -v $(pwd):/app socialseed-e2e run --verbose
+```
+
+#### Advanced Usage
+
+```bash
+# Run with debug mode
+docker run --rm -v $(pwd):/app socialseed-e2e run --debug
+
+# Run in boring mode (disable AI features)
+docker run --rm -v $(pwd):/app socialseed-e2e run --no-agent
+
+# Generate JUnit report
+docker run --rm -v $(pwd):/app -v $(pwd)/reports:/app/reports socialseed-e2e run --report junit
+
+# Run specific test module
+docker run --rm -v $(pwd):/app socialseed-e2e run --service auth --module 01_login
+```
+
+### Docker in CI/CD
+
+Example GitHub Actions workflow using Docker:
+
+```yaml
+name: E2E Tests with Docker
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build Docker image
+        run: docker build -t socialseed-e2e .
+      
+      - name: Run E2E tests
+        run: docker run --rm -v $(pwd):/app socialseed-e2e run --report junit
+      
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ./reports/junit.xml
+```
+
+### Benefits of Docker Usage
+
+- **No local installation**: No need to install Python, Playwright, or dependencies
+- **Consistent environment**: Same environment across dev, CI, and production
+- **Isolated execution**: Tests run in a clean, isolated container
+- **Easy CI/CD integration**: Simple to integrate with any CI/CD platform
+- **Version pinning**: Use specific versions of the framework via Docker tags
+
+---
+
 ## 🤖 Built for AI Agents (Recommended)
 
 **This framework was designed from the ground up for AI agents.**


### PR DESCRIPTION
Add official Docker support for containerized test execution.

Dockerfile features:
- Based on python:3.11-slim (Python 3.10+)
- Installs all system dependencies required by Playwright
- Copies project files and installs via pip
- Installs Chromium browser and dependencies
- Creates non-root user (e2euser) for security
- Sets ENTRYPOINT to e2e CLI command
- Default CMD shows help

Documentation added to README.md:
- Building the Docker image instructions
- Basic usage examples (run, service filter, verbose)
- Advanced usage (debug mode, boring mode, JUnit reports)
- CI/CD integration example with GitHub Actions
- Benefits of using Docker

Usage examples:
  docker build -t socialseed-e2e . docker run --rm socialseed-e2e --help docker run --rm -v /home/dairon/proyectos/socialseed-e2e:/app socialseed-e2e run docker run --rm -v /home/dairon/proyectos/socialseed-e2e:/app socialseed-e2e run --service users-api

Acceptance Criteria:
✅ Dockerfile successfully builds an image
✅ Container can execute e2e run commands natively
✅ Documentation added to README.md

